### PR TITLE
Added string operations for length and charAt

### DIFF
--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -574,6 +574,8 @@ trait GeneralMacros {
       case ("Max",        a: Double,  b: Double,  _)  => Constant(max(a, b))
 
       case ("Substring",  a: String,  b: Int,     _)  => Constant(a.substring(b))
+      case ("Length",     a: String,  _,          _)  => Constant(a.length)
+      case ("CharAt",     a: String,  b: Int,     _)  => Constant(a.charAt(b))
 
       case _ => abort(s"Unsupported $funcName[$aValue, $bValue, $cValue]", true)
     }

--- a/src/main/scala/singleton/ops/package.scala
+++ b/src/main/scala/singleton/ops/package.scala
@@ -72,4 +72,6 @@ package object ops {
   type Min[P1, P2]          = OpMacro["Min",P1, P2, 0]
   type Max[P1, P2]          = OpMacro["Max",P1, P2, 0]
   type Substring[P1, P2]    = OpMacro["Substring",P1, P2, 0]
+  type Length[P1]           = OpMacro["Length", P1, 0, 0]
+  type CharAt[P1, P2]       = OpMacro["CharAt", P1, P2, 0]
 }

--- a/src/test/scala/singleton/ops/CharAtSpec.scala
+++ b/src/test/scala/singleton/ops/CharAtSpec.scala
@@ -1,0 +1,11 @@
+package singleton.ops
+
+import org.scalacheck.Properties
+import singleton.ops.TestUtils._
+
+class CharAtSpec extends Properties("CharAt") {
+  property("foobar.charAt(3) == b") = wellTyped {
+    def charAt[P1 <: XString, P2 <: XInt](implicit op : CharAt[P1, P2]) : op.Out{} = op.value
+    val r : 'b' = charAt["foobar", 3]
+  }
+}

--- a/src/test/scala/singleton/ops/LengthSpec.scala
+++ b/src/test/scala/singleton/ops/LengthSpec.scala
@@ -1,0 +1,11 @@
+package singleton.ops
+
+import org.scalacheck.Properties
+import singleton.ops.TestUtils._
+
+class LengthSpec extends Properties("Length") {
+  property("foobar.length == 6") = wellTyped {
+    def length[P1 <: XString](implicit op : Length[P1]) : op.Out{} = op.value
+    val r : 6 = length["foobar"]
+  }
+}


### PR DESCRIPTION
I've added a couple of operations for strings.

Length: return the length of the string.
CharAt: return the character at an index within the string.

I notice that both Substring and CharAt could potentially fail due to indexes being out of bounds -- I haven't attempted to add any guards so that CharAt, or the existing Substring are only defined for indexes within `o <= i < Length`.