### PR TITLE
Remove custom resolver from usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ The latest version of the library is 0.0.4, which is available for Typelevel Sca
 If you're using sbt, add the following to your build:
 
 ```sbt
-resolvers ++= Seq(Resolver.bintrayRepo("fthomas", "maven"))
-
 libraryDependencies ++= Seq(
   "eu.timepit" %% "singleton-ops" % "0.0.4"
 )


### PR DESCRIPTION
... because singleton-ops is now on Maven Central.