### PR TITLE
Scalajs support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: scala
+sudo: required
 scala:
 # - 2.11.11-bin-typelevel-4
  - 2.12.3

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val singleton_ops = crossProject
     scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")),
     sources in (Compile,doc) := Seq.empty, // disable scaladoc due to https://github.com/scalameta/paradise/issues/55
     publishArtifact in (Compile, packageDoc) := false, // disable scaladoc
-    sbt.addCompilerPlugin("org.scalameta" % "paradise" % macroParadise3Version cross CrossVersion.patch)
+    sbt.addCompilerPlugin("org.scalameta" % "paradise" % macroParadise3Version cross CrossVersion.patch),
     resolvers += Resolver.bintrayRepo("singleton-ops", "maven")
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,10 @@ bintrayOrganization := Some("core-act-ness")
 bintrayRepository := "maven"
 
 /// projects
-lazy val root = project.in(file(".")).
-  aggregate(singleton_opsJVM, singleton_opsJS).
-  settings(
+lazy val root = project.in(file("."))
+  .settings(commonSettings)
+  .aggregate(singleton_opsJVM, singleton_opsJS)
+  .settings(
     publish := {},
     publishLocal := {}
   )
@@ -49,6 +50,9 @@ lazy val singleton_ops = crossProject
     publishArtifact in (Compile, packageDoc) := false, // disable scaladoc
     sbt.addCompilerPlugin("org.scalameta" % "paradise" % macroParadise3Version cross CrossVersion.patch)
     resolvers += Resolver.bintrayRepo("singleton-ops", "maven")
+  )
+  .jsSettings(
+    coverageEnabled := false
   )
 
 lazy val singleton_opsJVM = singleton_ops.jvm
@@ -193,6 +197,8 @@ lazy val miscSettings = Def.settings(
 val validateCommands = Seq(
   "clean",
   //"scalafmtTest",
+  "test:compile",
+  "singleton_opsJS/test",
   "coverage",
   "test",
   "coverageReport",

--- a/build.sbt
+++ b/build.sbt
@@ -17,18 +17,26 @@ bintrayOrganization := Some("core-act-ness")
 bintrayRepository := "maven"
 
 /// projects
+lazy val root = project.in(file(".")).
+  aggregate(singleton_opsJVM, singleton_opsJS).
+  settings(
+    publish := {},
+    publishLocal := {}
+  )
 
-lazy val root = project
+lazy val singleton_ops = crossProject
+  .crossType(CrossType.Pure)
   .in(file("."))
   .settings(commonSettings)
   .settings(publishSettings)
   .settings(
     libraryDependencies ++= Seq(
       scalaOrganization.value % "scala-compiler" % scalaVersion.value,
-      "org.typelevel" %% "macro-compat" % macroCompatVersion,
-      compilerPlugin("org.scalamacros" % "paradise" % macroParadiseVersion cross CrossVersion.patch),
-      "com.chuusai" %% "shapeless" % shapelessVersion,
-      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test
+      "org.typelevel" %%% "macro-compat" % macroCompatVersion,
+      compilerPlugin(
+        "org.scalamacros" % "paradise" % macroParadiseVersion cross CrossVersion.patch),
+      "com.chuusai" %%% "shapeless" % shapelessVersion,
+      "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test
     )
   )
   .settings( //Adds dependency of new-style scalameta and paradise macros
@@ -40,10 +48,11 @@ lazy val root = project
     sources in (Compile,doc) := Seq.empty, // disable scaladoc due to https://github.com/scalameta/paradise/issues/55
     publishArtifact in (Compile, packageDoc) := false, // disable scaladoc
     sbt.addCompilerPlugin("org.scalameta" % "paradise" % macroParadise3Version cross CrossVersion.patch)
-  ).settings(
-  resolvers += Resolver.bintrayRepo("singleton-ops", "maven")
+    resolvers += Resolver.bintrayRepo("singleton-ops", "maven")
+  )
 
-)
+lazy val singleton_opsJVM = singleton_ops.jvm
+lazy val singleton_opsJS  = singleton_ops.js
 
 /// settings
 

--- a/project/plugin-scalajs.sbt
+++ b/project/plugin-scalajs.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")

--- a/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
@@ -329,7 +329,7 @@ class TwoFaceDoubleSpec extends Properties("TwoFace.Double") {
   property("Safe toFloat") = verifyTFFloat(TwoFace.Double(1.0).toFloat, 1.0f)
   property("Unsafe toFloat") = verifyTFFloat(TwoFace.Double(us(1.0)).toFloat, us(1.0f))
   property("Safe toStringTF") = verifyTFString(TwoFace.Double(1.0).toStringTF, "1.0")
-  property("Unsafe toStringTF") = verifyTFString(TwoFace.Double(us(1.0)).toStringTF, us("1.0"))
+  property("Unsafe toStringTF") = verifyTFString(TwoFace.Double(us(1.5)).toStringTF, us("1.5"))
   property("Safe toSymbol") = {
     val sym = TwoFace.Double(2.0).toSymbol
     sym == scala.Symbol("2.0")
@@ -382,7 +382,7 @@ class TwoFaceDoubleSpec extends Properties("TwoFace.Double") {
   }
 
   property("ToString") = {
-    TwoFace.Double[W.`1.0`.T].toString() == "1.0"
+    TwoFace.Double[W.`1.5`.T].toString() == "1.5"
   }
 
   type Fin = W.`3.0`.T

--- a/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
@@ -326,7 +326,7 @@ class TwoFaceFloatSpec extends Properties("TwoFace.Float") {
   property("Safe toDouble") = verifyTFDouble(TwoFace.Float(1.0f).toDouble, 1.0)
   property("Unsafe toDouble") = verifyTFDouble(TwoFace.Float(us(1.0f)).toDouble, us(1.0))
   property("Safe toStringTF") = verifyTFString(TwoFace.Float(1.0f).toStringTF, "1.0")
-  property("Unsafe toStringTF") = verifyTFString(TwoFace.Float(us(1.0f)).toStringTF, us("1.0"))
+  property("Unsafe toStringTF") = verifyTFString(TwoFace.Float(us(1.5f)).toStringTF, us("1.5"))
   property("Safe toSymbol") = {
     val sym = TwoFace.Float(2.0f).toSymbol
     sym == scala.Symbol("2.0")
@@ -379,7 +379,7 @@ class TwoFaceFloatSpec extends Properties("TwoFace.Float") {
   }
 
   property("ToString") = {
-    TwoFace.Float[W.`1.0f`.T].toString() == "1.0"
+    TwoFace.Float[W.`1.5f`.T].toString() == "1.5"
   }
 
   type Fin = W.`3.0f`.T


### PR DESCRIPTION
This PR adds support for Scala.js, note that this implies a relatively large reorganization of the code but only a few changes to the code itself:

* Added a local implementation of `scala.Predef.valueOf` as this is not (yet) supported by scala.js see typelevel/scala#164
* A couple of tests don't work properly on Scala.js due to the way numbers are handled
* Disabled scoverage on scala.js as it is not well supported