### PR TITLE
Updated SBT, Scalac, and worked-around Scalac 2.11.11 test issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
    - "$HOME/.ivy2/cache"
    - "$HOME/.sbt/boot/"
 script:
- - sbt ++$TRAVIS_SCALA_VERSION validate
+ - travis_wait 60 sbt ++$TRAVIS_SCALA_VERSION validate
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 sudo: required
 scala:
-# - 2.11.11-bin-typelevel-4
- - 2.12.3
+ - 2.11.11
+ - 2.12.4
 jdk:
  - oraclejdk8
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val compileSettings = Def.settings(
     "-unchecked",
     "-Xfatal-warnings",
     "-Xfuture",
-    "-Xlint:-unused,_",
+//    "-Xlint:-unused,_",
 //    "-Yliteral-types",
     "-Yno-adapted-args",
     "-Ywarn-numeric-widen",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.0.4

--- a/project/plugin-bintray.sbt
+++ b/project/plugin-bintray.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+//addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")

--- a/project/plugin-bintray.sbt
+++ b/project/plugin-bintray.sbt
@@ -1,1 +1,1 @@
-//addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")

--- a/src/test/scala/singleton/ops/ImplicitConversionSpec.scala
+++ b/src/test/scala/singleton/ops/ImplicitConversionSpec.scala
@@ -8,8 +8,8 @@ class ImplicitConversionSpec extends Properties("ImplicitConversion") {
   property("OpToOp") = wellTyped {val ret : W.`2`.T + W.`1`.T = implicitly[W.`4`.T - W.`1`.T]}
   property("OpToSingleton") = wellTyped {val ret : W.`3`.T = implicitly[W.`4`.T - W.`1`.T]}
 //  property("SingletonToOp") = wellTyped {val ret : W.`2`.T + W.`1`.T = 3}
-  property("Wrong OpToOp") = {illTyped("""val ret : W.`2`.T + W.`1`.T = implicitly[W.`4`.T - W.`2`.T]"""); true}
-  property("Wrong OpToSingleton") = {illTyped("""val ret : W.`3`.T = implicitly[W.`4`.T - W.`2`.T]"""); true}
+  property("Wrong OpToOp") = {illTyped("""val impl = implicitly[W.`4`.T - W.`2`.T]; val ret : W.`2`.T + W.`1`.T = impl"""); true}
+  property("Wrong OpToSingleton") = {illTyped("""val impl = implicitly[W.`4`.T - W.`2`.T]; val ret : W.`3`.T = impl"""); true}
   property("Wrong SingletonToOp") = {illTyped("""val ret : W.`2`.T + W.`1`.T = W.`4`.T"""); true}
 //  property("ValueOf[Op]") = wellTyped {val ret : W.`3`.T = valueOf[W.`4`.T - W.`1`.T]}
 }

--- a/src/test/scala/singleton/twoface/TwoFaceBooleanSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceBooleanSpec.scala
@@ -84,8 +84,8 @@ class TwoFaceBooleanSpec extends Properties("TwoFace.Boolean") {
   }
 
   property("Wrong Implicit Conversions") = wellTyped {
-    illTyped("""val a : TwoFace.Boolean[W.`true`.T] = implicitly[TwoFace.Boolean[W.`false`.T && W.`true`.T]]""")
-    illTyped("""val b : TwoFace.Boolean[W.`false`.T && W.`true`.T] = implicitly[TwoFace.Boolean[W.`true`.T]]""")
+    illTyped("""val impl = implicitly[TwoFace.Boolean[W.`false`.T && W.`true`.T]]; val a : TwoFace.Boolean[W.`true`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Boolean[W.`true`.T]]; val b : TwoFace.Boolean[W.`false`.T && W.`true`.T] = impl""")
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
@@ -374,11 +374,10 @@ class TwoFaceDoubleSpec extends Properties("TwoFace.Double") {
     val e : Double = TwoFace.Double(us(3.0))
   }
 
-  property("Wrong Implicit Conversions") = {
+  property("Wrong Implicit Conversions") = wellTyped {
     illTyped("""val impl = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]; val a : TwoFace.Double[W.`3.0`.T] = impl""")
     illTyped("""val impl = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]; val b : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = impl""")
     illTyped("""val impl = implicitly[TwoFace.Double[W.`4.0`.T]]; val c : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = impl""")
-    true
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
@@ -375,9 +375,9 @@ class TwoFaceDoubleSpec extends Properties("TwoFace.Double") {
   }
 
   property("Wrong Implicit Conversions") = {
-    illTyped("""val a : TwoFace.Double[W.`3.0`.T] = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]""")
-    illTyped("""val b : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]""")
-    illTyped("""val c : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = implicitly[TwoFace.Double[W.`4.0`.T]]""")
+    illTyped("""val impl = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]; val a : TwoFace.Double[W.`3.0`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Double[W.`2.0`.T + W.`2.0`.T]]; val b : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Double[W.`4.0`.T]]; val c : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = impl""")
     true
   }
 

--- a/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
@@ -371,11 +371,10 @@ class TwoFaceFloatSpec extends Properties("TwoFace.Float") {
     val e : Float = TwoFace.Float(us(3.0f))
   }
 
-  property("Wrong Implicit Conversions") = {
-    illTyped("""val a : TwoFace.Float[W.`3.0f`.T] = implicitly[TwoFace.Float[W.`2.0f`.T + W.`2.0f`.T]]""")
-    illTyped("""val b : TwoFace.Float[W.`3.0f`.T + W.`0.0f`.T] = implicitly[TwoFace.Float[W.`2.0f`.T + W.`2.0f`.T]]""")
-    illTyped("""val c : TwoFace.Float[W.`3.0f`.T + W.`0.0f`.T] = implicitly[TwoFace.Float[W.`4.0f`.T]]""")
-    true
+  property("Wrong Implicit Conversions") = wellTyped {
+    illTyped("""val impl = implicitly[TwoFace.Float[W.`2.0f`.T + W.`2.0f`.T]]; val a : TwoFace.Float[W.`3.0f`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Float[W.`2.0f`.T + W.`2.0f`.T]]; val b : TwoFace.Float[W.`3.0f`.T + W.`0.0f`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Float[W.`4.0f`.T]]; val c : TwoFace.Float[W.`3.0f`.T + W.`0.0f`.T] = impl""")
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceIntSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceIntSpec.scala
@@ -353,11 +353,10 @@ class TwoFaceIntSpec extends Properties("TwoFace.Int") {
     val conv11 : W.`3`.T = implicitly[TwoFace.Int[Id[W.`3`.T]]]
   }
 
-  property("Wrong Implicit Conversions") = {
-    illTyped("""val a : TwoFace.Int[W.`3`.T] = implicitly[TwoFace.Int[W.`2`.T + W.`2`.T]]""")
-    illTyped("""val b : TwoFace.Int[W.`3`.T + W.`0`.T] = implicitly[TwoFace.Int[W.`2`.T + W.`2`.T]]""")
-    illTyped("""val c : TwoFace.Int[W.`3`.T + W.`0`.T] = implicitly[TwoFace.Int[W.`4`.T]]""")
-    true
+  property("Wrong Implicit Conversions") = wellTyped {
+    illTyped("""val impl = implicitly[TwoFace.Int[W.`2`.T + W.`2`.T]]; val a : TwoFace.Int[W.`3`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Int[W.`2`.T + W.`2`.T]]; val b : TwoFace.Int[W.`3`.T + W.`0`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Int[W.`4`.T]]; val c : TwoFace.Int[W.`3`.T + W.`0`.T] = impl""")
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceLongSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceLongSpec.scala
@@ -347,9 +347,9 @@ class TwoFaceLongSpec extends Properties("TwoFace.Long") {
   }
 
   property("Wrong Implicit Conversions") = wellTyped {
-    illTyped("""val a : TwoFace.Long[W.`3L`.T] = implicitly[TwoFace.Long[W.`2L`.T + W.`2L`.T]]""")
-    illTyped("""val b : TwoFace.Long[W.`3L`.T + W.`0L`.T] = implicitly[TwoFace.Long[W.`2L`.T + W.`2L`.T]]""")
-    illTyped("""val c : TwoFace.Long[W.`3L`.T + W.`0L`.T] = implicitly[TwoFace.Long[W.`4L`.T]]""")
+    illTyped("""val impl = implicitly[TwoFace.Long[W.`2L`.T + W.`2L`.T]]; val a : TwoFace.Long[W.`3L`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Long[W.`2L`.T + W.`2L`.T]]; val b : TwoFace.Long[W.`3L`.T + W.`0L`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.Long[W.`4L`.T]]; val c : TwoFace.Long[W.`3L`.T + W.`0L`.T] = impl""")
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceStringSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceStringSpec.scala
@@ -93,8 +93,8 @@ class TwoFaceStringSpec extends Properties("TwoFace.String") {
   }
 
   property("Wrong Implicit Conversions") = wellTyped {
-    illTyped("""val a : TwoFace.String[W.`"Some"`.T] = implicitly[TwoFace.String[W.`"Som"`.T + W.`"E"`.T]]""")
-    illTyped("""val b : TwoFace.String[W.`"Some"`.T + W.`"thing"`.T] = implicitly[TwoFace.String[W.`"SomeThing"`.T]]""")
+    illTyped("""val impl = implicitly[TwoFace.String[W.`"Som"`.T + W.`"E"`.T]]; val a : TwoFace.String[W.`"Some"`.T] = impl""")
+    illTyped("""val impl = implicitly[TwoFace.String[W.`"SomeThing"`.T]]; val b : TwoFace.String[W.`"Some"`.T + W.`"thing"`.T] = impl""")
   }
 
   type Fin = W.`"a"`.T


### PR DESCRIPTION
Updated SBT to 1.0.4 
Updated Scalac to 2.12.4
Worked-around tests for 2.11.11 that caused compiler crash due to scalac issue.
The tests failed because a scalac issue caused a compiler crash which was treated as a "good typecheck" by `illTyped`.
So instead of
```illTyped("""val ret : W.`2`.T + W.`1`.T = implicitly[W.`4`.T - W.`2`.T]""")```
We use
```illTyped("""val impl = implicitly[W.`4`.T - W.`2`.T]; val ret : W.`2`.T + W.`1`.T = impl""")```

Also opened issue for `illTyped` https://github.com/milessabin/shapeless/issues/789