### PR TITLE
Don't compile files on the root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ lazy val root = project.in(file("."))
   .aggregate(singleton_opsJVM, singleton_opsJS)
   .settings(noPublishSettings)
   .settings(
+    sources in Compile := Seq.empty,
+    sources in Test := Seq.empty
   )
 
 lazy val singleton_ops = crossProject
@@ -200,7 +202,7 @@ val validateCommands = Seq(
   "test:compile",
   "singleton_opsJS/test",
   "coverage",
-  "test",
+  "singleton_opsJVM/test",
   "coverageReport",
   "coverageOff",
   "doc"

--- a/project/plugin-scalajs.sbt
+++ b/project/plugin-scalajs.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")


### PR DESCRIPTION
For some reason I don't fully understand this projects compiles three times, one for root, one for JVM and one for JS

This simple fix will just skip compilation for the root and reduce the time to build

I took the opportunity to also update scala.js to 0.6.21