### PR TITLE
Downgrading SBT to 0.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import scala.sys.process._
+//import scala.sys.process._
 
 /// variables
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=0.13.16


### PR DESCRIPTION
We want to support the SBT advancement, but unfortunately there is serious build performance regression for singleton-ops. See https://github.com/sbt/sbt/issues/3783

We will revisit SBT 1.x once those issues are resolved.
@fthomas 