### PR TITLE
Removing macro annotations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,8 @@ val gitDevUrl = s"git@github.com:fthomas/$projectName.git"
 
 val macroCompatVersion = "1.1.1"
 val macroParadiseVersion = "2.1.0"
-val macroParadise3Version = "3.0.0-M10"
 val shapelessVersion = "2.3.2"
 val scalaCheckVersion = "1.13.4"
-val scalaMetaVersion = "1.8.0"
 
 /// projects
 lazy val root = project.in(file("."))
@@ -101,13 +99,8 @@ lazy val compileSettings = Def.settings(
     compilerPlugin(
     "org.scalamacros" % "paradise" % macroParadiseVersion cross CrossVersion.patch),
     "com.chuusai" %%% "shapeless" % shapelessVersion,
-    "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test,
-    "org.scalameta" %%% "scalameta" % scalaMetaVersion % Provided
-  ),
-  // macroparadise plugin doesn't work in repl
-  scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")),
-  sources in (Compile,doc) := Seq.empty, // disable scaladoc due to https://github.com/scalameta/paradise/issues/55
-  sbt.addCompilerPlugin("org.scalameta" % "paradise" % macroParadise3Version cross CrossVersion.patch)
+    "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test
+  )
 )
 
 lazy val scaladocSettings = Def.settings(

--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -1443,13 +1443,13 @@ trait GeneralMacros {
         abort(
           """
             |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
             |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       val fixedCondTpe = condTpe.substituteTypes(List(condTpe.typeArgs.head.typeSymbol), List(outTpe))
       val fixedMsgTpe = msgTpe.substituteTypes(List(msgTpe.typeArgs.head.typeSymbol), List(outTpe))
@@ -1519,13 +1519,13 @@ trait GeneralMacros {
         abort(
           """
             |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
             |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
 
       val fixedCondTpe = condTpe.substituteTypes(condTpe.typeArgs.map(t => t.typeSymbol), List(tCalc.tpe, paramCalc.tpe))

--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -1442,16 +1442,14 @@ trait GeneralMacros {
       if (condTpe.typeArgs.isEmpty)
         abort(
           """
-            |Unable to analyze given `Cond`. Try adding the following workaround lines at the call site:
-            |  type WorkAround0[T]
-            |  object WorkAround0 extends _root_.singleton.twoface.impl.Checked0Param.Builder[Nothing, WorkAround0, WorkAround0, Nothing]
+            |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
+            |    object CheckedWorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
-            |Unable to analyze given `Msg`. Try adding the following workaround lines at the call site:
-            |  type WorkAround0[T]
-            |  object WorkAround0 extends _root_.singleton.twoface.impl.Checked0Param.Builder[Nothing, WorkAround0, WorkAround0, Nothing]
+            |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
+            |    object CheckedWorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       val fixedCondTpe = condTpe.substituteTypes(List(condTpe.typeArgs.head.typeSymbol), List(outTpe))
       val fixedMsgTpe = msgTpe.substituteTypes(List(msgTpe.typeArgs.head.typeSymbol), List(outTpe))
@@ -1520,16 +1518,14 @@ trait GeneralMacros {
       if (condTpe.typeArgs.isEmpty)
         abort(
           """
-            |Unable to analyze given `Cond`. Try adding the following workaround lines at the call site:
-            |  type WorkAround1[T,P]
-            |  object WorkAround1 extends _root_.singleton.twoface.impl.Checked1Param.Builder[Nothing, WorkAround1, WorkAround1, Nothing, Nothing]
+            |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
+            |    object CheckedWorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
-            |Unable to analyze given `Msg`. Try adding the following workaround lines at the call site:
-            |  type WorkAround1[T,P]
-            |  object WorkAround1 extends _root_.singleton.twoface.impl.Checked1Param.Builder[Nothing, WorkAround1, WorkAround1, Nothing, Nothing]
+            |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
+            |    object CheckedWorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
 
       val fixedCondTpe = condTpe.substituteTypes(condTpe.typeArgs.map(t => t.typeSymbol), List(tCalc.tpe, paramCalc.tpe))

--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -1443,13 +1443,13 @@ trait GeneralMacros {
         abort(
           """
             |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround0 extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
             |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround0 extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       val fixedCondTpe = condTpe.substituteTypes(List(condTpe.typeArgs.head.typeSymbol), List(outTpe))
       val fixedMsgTpe = msgTpe.substituteTypes(List(msgTpe.typeArgs.head.typeSymbol), List(outTpe))
@@ -1519,13 +1519,13 @@ trait GeneralMacros {
         abort(
           """
             |Unable to analyze given `Cond`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround1 extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
       if (msgTpe.typeArgs.isEmpty)
         abort(
           """
             |Unable to analyze given `Msg`. Try adding the following workaround line at the call site:
-            |    object CheckedWorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+            |    object CheckedWorkAround1 extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
           """.stripMargin)
 
       val fixedCondTpe = condTpe.substituteTypes(condTpe.typeArgs.map(t => t.typeSymbol), List(tCalc.tpe, paramCalc.tpe))

--- a/src/main/scala/singleton/twoface/Checked.scala
+++ b/src/main/scala/singleton/twoface/Checked.scala
@@ -1,9 +1,5 @@
 package singleton.twoface
 
-import scala.meta._
-import singleton.ops._
-import scala.collection.immutable.Seq
-
 object Checked {
   type F1[_]
   type F2[_,_]
@@ -15,67 +11,4 @@ object Checked {
     impl.CheckedShell2[Cond, Msg, impl.CheckedShell2[F2,F2,_,_,_,_,_], Arg1, Arg1Wide, Arg2, Arg2Wide]
   type Shell2Sym[Cond[_,_], Msg[_,_], Sym, Arg1, Arg1Wide, Arg2, Arg2Wide] =
     impl.CheckedShell2[Cond, Msg, Sym, Arg1, Arg1Wide, Arg2, Arg2Wide]
-}
-
-class checked0Param[Cond[_], Msg[_], TFace] extends scala.annotation.StaticAnnotation {
-  inline def apply(defn: Any): Any = meta {
-    defn match {
-      case cls @ Defn.Class(_, name, _, ctor, _) =>
-        val q"type T = $tFaceName" = q"type T = $TFace"
-        val chkNameStr = name.value
-        val chkTypeName = Type.Name(chkNameStr)
-        val chkTermName = Term.Name(chkNameStr)
-        val updatedCls =
-          q"""
-             final class $chkTypeName[T] (val value : $TFace) extends AnyVal with
-               _root_.singleton.twoface.impl.Checked0Param[$chkTypeName, $Cond, $Msg, $TFace, T] with
-               ${Ctor.Name("_root_.singleton.twoface.impl.TwoFaceAny." + tFaceName.toString())}[T] {
-               @inline def getValue : $TFace = value
-             }
-           """
-        val companion =
-          q"""
-             object $chkTermName extends _root_.singleton.twoface.impl.Checked0Param.Builder[$chkTypeName, $Cond, $Msg, $TFace] {
-             }
-           """
-        val termBlock = Term.Block(Seq(updatedCls, companion))
-//        print(termBlock)
-        termBlock
-      case _ =>
-//        println(defn.structure)
-        abort("@checked must annotate a class.")
-    }
-  }
-}
-
-
-class checked1Param[Cond[_,_], Msg[_,_], TFace, ParamFace] extends scala.annotation.StaticAnnotation {
-  inline def apply(defn: Any): Any = meta {
-    defn match {
-      case cls @ Defn.Class(_, name, _, ctor, _) =>
-        val q"type T = $tFaceName" = q"type T = $TFace"
-        val chkNameStr = name.value
-        val chkTypeName = Type.Name(chkNameStr)
-        val chkTermName = Term.Name(chkNameStr)
-        val updatedCls =
-          q"""
-             final class $chkTypeName[T, Param] (val value : $TFace) extends AnyVal with
-               _root_.singleton.twoface.impl.Checked1Param[$chkTypeName, $Cond, $Msg, $TFace, T, $ParamFace, Param] with
-               ${Ctor.Name("_root_.singleton.twoface.impl.TwoFaceAny." + tFaceName.toString())}[T] {
-               @inline def getValue : $TFace = value
-             }
-           """
-        val companion =
-          q"""
-             object $chkTermName extends _root_.singleton.twoface.impl.Checked1Param.Builder[$chkTypeName, $Cond, $Msg, $TFace, $ParamFace] {
-             }
-           """
-        val termBlock = Term.Block(Seq(updatedCls, companion))
-        //        print(termBlock)
-        termBlock
-      case _ =>
-        //        println(defn.structure)
-        abort("@checked must annotate a class.")
-    }
-  }
 }

--- a/src/main/scala/singleton/twoface/Checked.scala
+++ b/src/main/scala/singleton/twoface/Checked.scala
@@ -63,7 +63,7 @@ object Checked1Param {
   //    @inline def getValue : Char = value
   //  }
   //  object Checked extends Checked1Param.Char.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Char {
@@ -83,7 +83,7 @@ object Checked1Param {
   //    @inline def getValue : Int = value
   //  }
   //  object Checked extends Checked1Param.Int.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Int {
@@ -103,7 +103,7 @@ object Checked1Param {
   //    @inline def getValue : Long = value
   //  }
   //  object Checked extends Checked1Param.Long.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Long {
@@ -123,7 +123,7 @@ object Checked1Param {
   //    @inline def getValue : Float = value
   //  }
   //  object Checked extends Checked1Param.Float.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Float {
@@ -143,7 +143,7 @@ object Checked1Param {
   //    @inline def getValue : Double = value
   //  }
   //  object Checked extends Checked1Param.Double.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Double {
@@ -163,7 +163,7 @@ object Checked1Param {
   //    @inline def getValue : String = value
   //  }
   //  object Checked extends Checked1Param.String.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object String {
@@ -183,7 +183,7 @@ object Checked1Param {
   //    @inline def getValue : Boolean = value
   //  }
   //  object Checked extends Checked1Param.Boolean.CO[Checked, Cond, Msg, ParamFace]
-  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
   ///////////////////////////////////////////////
   object Boolean {

--- a/src/main/scala/singleton/twoface/Checked.scala
+++ b/src/main/scala/singleton/twoface/Checked.scala
@@ -1,4 +1,6 @@
 package singleton.twoface
+import impl._
+import singleton.ops.impl.std
 
 object Checked {
   type F1[_]
@@ -11,4 +13,77 @@ object Checked {
     impl.CheckedShell2[Cond, Msg, impl.CheckedShell2[F2,F2,_,_,_,_,_], Arg1, Arg1Wide, Arg2, Arg2Wide]
   type Shell2Sym[Cond[_,_], Msg[_,_], Sym, Arg1, Arg1Wide, Arg2, Arg2Wide] =
     impl.CheckedShell2[Cond, Msg, Sym, Arg1, Arg1Wide, Arg2, Arg2Wide]
+}
+
+object Checked0Param {
+  //CC: traits used for the checked class
+  //CO: traits used for the checked companion object
+  object Char {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Char, T] with TwoFaceAny.Char[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Char]
+  }
+  object Int {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Int, T] with TwoFaceAny.Int[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Int]
+  }
+  object Long {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Long, T] with TwoFaceAny.Long[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Long]
+  }
+  object Float {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Float, T] with TwoFaceAny.Float[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Float]
+  }
+  object Double {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Double, T] with TwoFaceAny.Double[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Double]
+  }
+  object String {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.String, T] with TwoFaceAny.String[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.String]
+  }
+  object Boolean {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Boolean, T] with TwoFaceAny.Boolean[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Boolean]
+  }
+}
+
+object Checked1Param {
+  //CC: traits used for the checked class
+  //CO: traits used for the checked companion object
+  object Char {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Char, T, ParamFace, Param] with TwoFaceAny.Char[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Char, ParamFace]
+  }
+  object Int {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Int, T, ParamFace, Param] with TwoFaceAny.Int[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Int, ParamFace]
+  }
+  object Long {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Long, T, ParamFace, Param] with TwoFaceAny.Long[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Long, ParamFace]
+  }
+  object Float {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Float, T, ParamFace, Param] with TwoFaceAny.Float[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Float, ParamFace]
+  }
+  object Double {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Double, T, ParamFace, Param] with TwoFaceAny.Double[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Double, ParamFace]
+  }
+  object String {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.String, T, ParamFace, Param] with TwoFaceAny.String[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.String, ParamFace]
+  }
+  object Boolean {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.Boolean, T, ParamFace, Param] with TwoFaceAny.Boolean[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Boolean, ParamFace]
+  }
 }

--- a/src/main/scala/singleton/twoface/Checked.scala
+++ b/src/main/scala/singleton/twoface/Checked.scala
@@ -18,30 +18,127 @@ object Checked {
 object Checked0Param {
   //CC: traits used for the checked class
   //CO: traits used for the checked companion object
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Char 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Char) extends AnyVal with Checked0Param.Char.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Char = value
+  //  }
+  //  object Checked extends Checked0Param.Char.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Char {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Char, T] with TwoFaceAny.Char[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Char]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Int 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Int) extends AnyVal with Checked0Param.Int.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Int = value
+  //  }
+  //  object Checked extends Checked0Param.Int.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Int {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Int, T] with TwoFaceAny.Int[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Int]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Long 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Long) extends AnyVal with Checked0Param.Long.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Long = value
+  //  }
+  //  object Checked extends Checked0Param.Long.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Long {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Long, T] with TwoFaceAny.Long[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Long]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Float 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Float) extends AnyVal with Checked0Param.Float.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Float = value
+  //  }
+  //  object Checked extends Checked0Param.Float.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Float {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Float, T] with TwoFaceAny.Float[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Float]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Double 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Double) extends AnyVal with Checked0Param.Double.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Double = value
+  //  }
+  //  object Checked extends Checked0Param.Double.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Double {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Double, T] with TwoFaceAny.Double[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Double]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.String 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : String) extends AnyVal with Checked0Param.String.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : String = value
+  //  }
+  //  object Checked extends Checked0Param.String.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object String {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.String, T] with TwoFaceAny.String[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.String]
   }
+
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Boolean 0-Params type
+  /////////////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T] = /* Your condition here */
+  //  type Msg[T] = /* Your message here */
+  //  final class Checked[T](val value : Boolean) extends AnyVal with Checked0Param.Boolean.CC[Checked, Cond, Msg, T] {
+  //    @inline def getValue : Boolean = value
+  //  }
+  //  object Checked extends Checked0Param.Boolean.CO[Checked, Cond, Msg]
+  //  object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  //}
+  /////////////////////////////////////////////////////
   object Boolean {
     trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Boolean, T] with TwoFaceAny.Boolean[T]
     trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Boolean]
@@ -52,9 +149,9 @@ object Checked1Param {
   //CC: traits used for the checked class
   //CO: traits used for the checked companion object
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Char type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Char 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -65,16 +162,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Char.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Char {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Char, T, ParamFace, Param] with TwoFaceAny.Char[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Char, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Int type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Int 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -85,16 +182,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Int.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Int {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Int, T, ParamFace, Param] with TwoFaceAny.Int[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Int, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Long type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Long 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -105,16 +202,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Long.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Long {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Long, T, ParamFace, Param] with TwoFaceAny.Long[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Long, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Float type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Float 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -125,16 +222,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Float.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Float {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Float, T, ParamFace, Param] with TwoFaceAny.Float[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Float, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Double type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Double 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -145,16 +242,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Double.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Double {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Double, T, ParamFace, Param] with TwoFaceAny.Double[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Double, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.String type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.String 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -165,16 +262,16 @@ object Checked1Param {
   //  object Checked extends Checked1Param.String.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object String {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.String, T, ParamFace, Param] with TwoFaceAny.String[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.String, ParamFace]
   }
 
-  ///////////////////////////////////////////////
-  // Template to define a Checked.Boolean type
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
+  // Template to define a Checked.Boolean 1-Params type
+  /////////////////////////////////////////////////////
   //object /* Name this object */ {
   //  type Cond[T, P] = /* Your condition here */
   //  type Msg[T, P] = /* Your message here */
@@ -185,7 +282,7 @@ object Checked1Param {
   //  object Checked extends Checked1Param.Boolean.CO[Checked, Cond, Msg, ParamFace]
   //  object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   //}
-  ///////////////////////////////////////////////
+  /////////////////////////////////////////////////////
   object Boolean {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Boolean, T, ParamFace, Param] with TwoFaceAny.Boolean[T]

--- a/src/main/scala/singleton/twoface/Checked.scala
+++ b/src/main/scala/singleton/twoface/Checked.scala
@@ -51,36 +51,141 @@ object Checked0Param {
 object Checked1Param {
   //CC: traits used for the checked class
   //CO: traits used for the checked companion object
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Char type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Char) extends AnyVal with Checked1Param.Char.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Char = value
+  //  }
+  //  object Checked extends Checked1Param.Char.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Char {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Char, T, ParamFace, Param] with TwoFaceAny.Char[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Char, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Int type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Int) extends AnyVal with Checked1Param.Int.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Int = value
+  //  }
+  //  object Checked extends Checked1Param.Int.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Int {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Int, T, ParamFace, Param] with TwoFaceAny.Int[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Int, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Long type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Long) extends AnyVal with Checked1Param.Long.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Long = value
+  //  }
+  //  object Checked extends Checked1Param.Long.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Long {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Long, T, ParamFace, Param] with TwoFaceAny.Long[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Long, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Float type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Float) extends AnyVal with Checked1Param.Float.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Float = value
+  //  }
+  //  object Checked extends Checked1Param.Float.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Float {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Float, T, ParamFace, Param] with TwoFaceAny.Float[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Float, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Double type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Double) extends AnyVal with Checked1Param.Double.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Double = value
+  //  }
+  //  object Checked extends Checked1Param.Double.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Double {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Double, T, ParamFace, Param] with TwoFaceAny.Double[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.Double, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.String type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : String) extends AnyVal with Checked1Param.String.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : String = value
+  //  }
+  //  object Checked extends Checked1Param.String.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object String {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.String, T, ParamFace, Param] with TwoFaceAny.String[T]
     trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.String, ParamFace]
   }
+
+  ///////////////////////////////////////////////
+  // Template to define a Checked.Boolean type
+  ///////////////////////////////////////////////
+  //object /* Name this object */ {
+  //  type Cond[T, P] = /* Your condition here */
+  //  type Msg[T, P] = /* Your message here */
+  //  type ParamFace = /* The parameter base type (e.g., Int) */
+  //  final class Checked[T, Param](val value : Boolean) extends AnyVal with Checked1Param.Boolean.CC[Checked, Cond, Msg, T, ParamFace, Param] {
+  //    @inline def getValue : Boolean = value
+  //  }
+  //  object Checked extends Checked1Param.Boolean.CO[Checked, Cond, Msg, ParamFace]
+  //  object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  //}
+  ///////////////////////////////////////////////
   object Boolean {
     trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
       Checked1ParamAny[Chk, Cond, Msg, std.Boolean, T, ParamFace, Param] with TwoFaceAny.Boolean[T]

--- a/src/main/scala/singleton/twoface/TwoFace.scala
+++ b/src/main/scala/singleton/twoface/TwoFace.scala
@@ -1,6 +1,7 @@
 package singleton.twoface
 
 import impl._
+import singleton.ops.impl.std
 
 object TwoFace {
   type Char[T0] = TwoFaceAny.Char[T0]
@@ -23,4 +24,47 @@ object TwoFace {
 
   type Boolean[T0] = TwoFaceAny.Boolean[T0]
   val Boolean = TwoFaceAny.Boolean
+}
+
+object Checked0Param {
+  //CC: traits used for the checked class
+  //CO: traits used for the checked companion object
+  object Char {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Char, T] with TwoFaceAny.Char[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Char]
+  }
+  object Int {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Int, T] with TwoFaceAny.Int[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Int]
+  }
+  object Long {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Long, T] with TwoFaceAny.Long[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Long]
+  }
+  object Float {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Float, T] with TwoFaceAny.Float[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Float]
+  }
+  object Double {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Double, T] with TwoFaceAny.Double[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Double]
+  }
+  object String {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.String, T] with TwoFaceAny.String[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.String]
+  }
+  object Boolean {
+    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Boolean, T] with TwoFaceAny.Boolean[T]
+    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Boolean]
+  }
+}
+
+object Checked1Param {
+  //CC: traits used for the checked class
+  //CO: traits used for the checked companion object
+  object String {
+    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
+      Checked1ParamAny[Chk, Cond, Msg, std.String, T, ParamFace, Param] with TwoFaceAny.String[T]
+    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.String, ParamFace]
+  }
 }

--- a/src/main/scala/singleton/twoface/TwoFace.scala
+++ b/src/main/scala/singleton/twoface/TwoFace.scala
@@ -1,7 +1,6 @@
 package singleton.twoface
 
 import impl._
-import singleton.ops.impl.std
 
 object TwoFace {
   type Char[T0] = TwoFaceAny.Char[T0]
@@ -24,47 +23,4 @@ object TwoFace {
 
   type Boolean[T0] = TwoFaceAny.Boolean[T0]
   val Boolean = TwoFaceAny.Boolean
-}
-
-object Checked0Param {
-  //CC: traits used for the checked class
-  //CO: traits used for the checked companion object
-  object Char {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Char, T] with TwoFaceAny.Char[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Char]
-  }
-  object Int {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Int, T] with TwoFaceAny.Int[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Int]
-  }
-  object Long {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Long, T] with TwoFaceAny.Long[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Long]
-  }
-  object Float {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Float, T] with TwoFaceAny.Float[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Float]
-  }
-  object Double {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Double, T] with TwoFaceAny.Double[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Double]
-  }
-  object String {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.String, T] with TwoFaceAny.String[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.String]
-  }
-  object Boolean {
-    trait CC[Chk[_], Cond[_], Msg[_], T] extends Any with Checked0ParamAny[Chk, Cond, Msg, std.Boolean, T] with TwoFaceAny.Boolean[T]
-    trait CO[Chk[_], Cond[_], Msg[_]]    extends Checked0ParamAny.Builder[Chk, Cond, Msg, std.Boolean]
-  }
-}
-
-object Checked1Param {
-  //CC: traits used for the checked class
-  //CO: traits used for the checked companion object
-  object String {
-    trait CC[Chk[_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param] extends Any with
-      Checked1ParamAny[Chk, Cond, Msg, std.String, T, ParamFace, Param] with TwoFaceAny.String[T]
-    trait CO[Chk[_,_], Cond[_,_], Msg[_,_], ParamFace] extends Checked1ParamAny.Builder[Chk, Cond, Msg, std.String, ParamFace]
-  }
 }

--- a/src/main/scala/singleton/twoface/impl/Checked0ParamAny.scala
+++ b/src/main/scala/singleton/twoface/impl/Checked0ParamAny.scala
@@ -6,14 +6,14 @@ import singleton.ops.impl._
 
 import scala.reflect.macros.whitebox
 
-trait Checked0Param[Chk[_], Cond[_], Msg[_], Face, T] extends Any with TwoFaceAny[Face, T] {
+trait Checked0ParamAny[Chk[_], Cond[_], Msg[_], Face, T] extends Any with TwoFaceAny[Face, T] {
   def unsafeCheck()(implicit shl : CheckedShell1[Cond, Msg, Chk[_], Face, Face]) : Chk[T] = {
     shl.unsafeCheck(getValue)
     this.asInstanceOf[Chk[T]]
   }
 }
 
-object Checked0Param {
+object Checked0ParamAny {
   trait Builder[Chk[T], Cond[_], Msg[_], Face] {
     type Shell[T] = ShellSym[ShellSym[_,_], T]
     trait ShellSym[Sym, T] extends CheckedShell1[Cond, Msg, Sym, T, Face]
@@ -42,10 +42,10 @@ object Checked0Param {
     implicit def ev[T](implicit value : AcceptNonLiteral[Id[T]])
     : Chk[T] = macro Builder.Macro.fromOpImpl[T, Chk[_], Cond[_], Msg[_]]
 
-    implicit def fromNum[T <: Face, Out <: T](value : T)
+    implicit def fromNum[T >: Face, Out <: T](value : T)
     : Chk[Out] = macro Builder.Macro.fromNumValue[Chk[_], Cond[_], Msg[_]]
 
-    implicit def fromTF[T <: Face, Out <: T](value : TwoFaceAny[Face, T])
+    implicit def fromTF[T >: Face, Out <: T](value : TwoFaceAny[Face, T])
     : Chk[Out] = macro Builder.Macro.fromTF[Chk[_], Cond[_], Msg[_]]
     ////////////////////////////////////////////////////////////////////////////////////////
   }

--- a/src/main/scala/singleton/twoface/impl/Checked1ParamAny.scala
+++ b/src/main/scala/singleton/twoface/impl/Checked1ParamAny.scala
@@ -6,7 +6,7 @@ import singleton.ops.impl._
 
 import scala.reflect.macros.whitebox
 
-trait Checked1Param[Chk[_,_], Cond[_,_], Msg[_,_], Face, T, ParamFace, Param] extends Any with TwoFaceAny[Face, T] {
+trait Checked1ParamAny[Chk[_,_], Cond[_,_], Msg[_,_], Face, T, ParamFace, Param] extends Any with TwoFaceAny[Face, T] {
   def unsafeCheck(p : ParamFace)
     (implicit shl : CheckedShell2[Cond, Msg, Chk[_,_], Face, Face, ParamFace, ParamFace]) : Chk[T, Param] = {
     shl.unsafeCheck(getValue, p)
@@ -14,7 +14,7 @@ trait Checked1Param[Chk[_,_], Cond[_,_], Msg[_,_], Face, T, ParamFace, Param] ex
   }
 }
 
-object Checked1Param {
+object Checked1ParamAny {
   trait Builder[Chk[_,_], Cond[_,_], Msg[_,_], Face, ParamFace] {
     type Shell[T, Param] = ShellSym[ShellSym[_,_,_], T, Param]
     trait ShellSym[Sym, T, Param] extends CheckedShell2[Cond, Msg, Sym, T, Face, Param, ParamFace]
@@ -42,10 +42,10 @@ object Checked1Param {
     implicit def ev[T, Param](implicit value : AcceptNonLiteral[Id[T]], param : AcceptNonLiteral[Id[Param]])
     : Chk[T, Param] = macro Builder.Macro.fromOpImpl[T, Param, Chk[_,_], Cond[_,_], Msg[_,_]]
 
-    implicit def fromNum[T <: Face, Param <: ParamFace, Out <: T](value : T)(implicit param : AcceptNonLiteral[Id[Param]])
+    implicit def fromNum[T >: Face, Param, Out <: T](value : T)(implicit param : AcceptNonLiteral[Id[Param]])
     : Chk[Out, Param] = macro Builder.Macro.fromNumValue[Chk[_,_], Cond[_,_], Msg[_,_]]
 
-    implicit def fromTF[T <: Face, Param <: ParamFace, Out <: T](value : TwoFaceAny[Face, T])(implicit param : AcceptNonLiteral[Id[Param]])
+    implicit def fromTF[T >: Face, Param, Out <: T](value : TwoFaceAny[Face, T])(implicit param : AcceptNonLiteral[Id[Param]])
     : Chk[Out, Param] = macro Builder.Macro.fromTF[Chk[_,_], Cond[_,_], Msg[_,_]]
     ////////////////////////////////////////////////////////////////////////////////////////
   }

--- a/src/test/scala/singleton/ops/ExperimentingSpec.scala
+++ b/src/test/scala/singleton/ops/ExperimentingSpec.scala
@@ -211,8 +211,8 @@
 ////  type CondSmallerThan50[T, P] = T < P
 ////  type MsgSmallerThan50[T, P] = "This is bad " + ToString[T]
 ////  type Param50 = 50
-////  type CheckedSmallerThan50[T] = Checked.Int[T, CondSmallerThan50, Param50, MsgSmallerThan50]
-////  def smallerThan50[T](t : CheckedSmallerThan50[T]) : Unit = {
+////  type SmallerThan50.Check[T] = Checked.Int[T, CondSmallerThan50, Param50, MsgSmallerThan50]
+////  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {
 ////    require(t < 50, "") //if (rt_check)
 ////  }
 ////

--- a/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
@@ -9,10 +9,10 @@ object CheckedBooleanSpec {
   object True {
     type Cond[T] = T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Boolean) extends AnyVal with Checked0Param.Boolean.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Boolean) extends AnyVal with Checked0Param.Boolean.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Boolean = value
     }
-    object Check extends Checked0Param.Boolean.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Boolean.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -20,7 +20,7 @@ object CheckedBooleanSpec {
 class CheckedBooleanSpec extends Properties("Checked.Boolean") {
   import CheckedBooleanSpec._
 
-  def condTrue[T](t : True.Check[T]) : Unit = {t.unsafeCheck()}
+  def condTrue[T](t : True.Checked[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     condTrue(true)
@@ -36,7 +36,7 @@ class CheckedBooleanSpec extends Properties("Checked.Boolean") {
     illRun{condTrue(TwoFace.Boolean(us(false)))}
   }
 
-  def condTrueImpl[T](realValue : Boolean)(implicit t : True.Check.Shell[T]) : Unit = {t.unsafeCheck(realValue)}
+  def condTrueImpl[T](realValue : Boolean)(implicit t : True.Checked.Shell[T]) : Unit = {t.unsafeCheck(realValue)}
 
   property("Shell compile-time checks") = wellTyped {
     condTrueImpl[True](true)
@@ -51,7 +51,7 @@ class CheckedBooleanSpec extends Properties("Checked.Boolean") {
 
   trait CheckedUse[T]
   object CheckedUse {
-    implicit def ev[T](implicit checkedTrue: True.Check.ShellSym[CheckedUse[_], T]) : CheckedUse[T] =
+    implicit def ev[T](implicit checkedTrue: True.Checked.ShellSym[CheckedUse[_], T]) : CheckedUse[T] =
       new CheckedUse[T] {}
   }
 

--- a/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
@@ -6,16 +6,21 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedBooleanSpec {
-  type Cond[T] = T
-  type Msg[T] = W.`"Failed Check"`.T
-  @checked0Param[Cond, Msg, Boolean] class CheckedTrue[T]
-  illTyped("""@checked0Param[Cond, Msg, Boolean] trait CheckedTrueBad[T]""")
+  object True {
+    type Cond[T] = T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Boolean) extends AnyVal with Checked0Param.Boolean.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Boolean = value
+    }
+    object Check extends Checked0Param.Boolean.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedBooleanSpec extends Properties("Checked.Boolean") {
   import CheckedBooleanSpec._
 
-  def condTrue[T](t : CheckedTrue[T]) : Unit = {t.unsafeCheck()}
+  def condTrue[T](t : True.Check[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     condTrue(true)
@@ -31,7 +36,7 @@ class CheckedBooleanSpec extends Properties("Checked.Boolean") {
     illRun{condTrue(TwoFace.Boolean(us(false)))}
   }
 
-  def condTrueImpl[T](realValue : Boolean)(implicit t : CheckedTrue.Shell[T]) : Unit = {t.unsafeCheck(realValue)}
+  def condTrueImpl[T](realValue : Boolean)(implicit t : True.Check.Shell[T]) : Unit = {t.unsafeCheck(realValue)}
 
   property("Shell compile-time checks") = wellTyped {
     condTrueImpl[True](true)
@@ -46,7 +51,7 @@ class CheckedBooleanSpec extends Properties("Checked.Boolean") {
 
   trait CheckedUse[T]
   object CheckedUse {
-    implicit def ev[T](implicit checkedTrue: CheckedTrue.ShellSym[CheckedUse[_], T]) : CheckedUse[T] =
+    implicit def ev[T](implicit checkedTrue: True.Check.ShellSym[CheckedUse[_], T]) : CheckedUse[T] =
       new CheckedUse[T] {}
   }
 

--- a/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedBooleanSpec.scala
@@ -13,7 +13,7 @@ object CheckedBooleanSpec {
       @inline def getValue : Boolean = value
     }
     object Checked extends Checked0Param.Boolean.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedCharSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedCharSpec.scala
@@ -13,7 +13,7 @@ object CheckedCharSpec {
       @inline def getValue : Char = value
     }
     object Checked extends Checked0Param.Char.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedCharSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedCharSpec.scala
@@ -9,10 +9,10 @@ object CheckedCharSpec {
   object SmallerThan50 {
     type Cond[T] = T < W.`'\u0032'`.T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Char) extends AnyVal with Checked0Param.Char.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Char) extends AnyVal with Checked0Param.Char.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Char = value
     }
-    object Check extends Checked0Param.Char.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Char.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -20,7 +20,7 @@ object CheckedCharSpec {
 class CheckedCharSpec extends Properties("Checked.Char") {
   import CheckedCharSpec._
 
-  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Checked[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50('\u0020')

--- a/src/test/scala/singleton/twoface/CheckedCharSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedCharSpec.scala
@@ -6,15 +6,21 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedCharSpec {
-  type Cond[T] = T < W.`'\u0032'`.T
-  type Msg[T] = W.`"Failed Check"`.T
-  @checked0Param[Cond, Msg, Char] class CheckedSmallerThan50[T]
+  object SmallerThan50 {
+    type Cond[T] = T < W.`'\u0032'`.T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Char) extends AnyVal with Checked0Param.Char.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Char = value
+    }
+    object Check extends Checked0Param.Char.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedCharSpec extends Properties("Checked.Char") {
   import CheckedCharSpec._
 
-  def smallerThan50[T](t : CheckedSmallerThan50[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50('\u0020')

--- a/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
@@ -6,15 +6,21 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedDoubleSpec {
-  type Cond[T] = T < W.`50.0`.T
-  type Msg[T] = W.`"Failed Check"`.T
-  @checked0Param[Cond, Msg, Double] class CheckedSmallerThan50[T]
+  object SmallerThan50 {
+    type Cond[T] = T < W.`50.0`.T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Double) extends AnyVal with Checked0Param.Double.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Double = value
+    }
+    object Check extends Checked0Param.Double.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedDoubleSpec extends Properties("Checked.Double") {
   import CheckedDoubleSpec._
 
-  def smallerThan50[T](t : CheckedSmallerThan50[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40.0)

--- a/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
@@ -13,7 +13,7 @@ object CheckedDoubleSpec {
       @inline def getValue : Double = value
     }
     object Checked extends Checked0Param.Double.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedDoubleSpec.scala
@@ -9,10 +9,10 @@ object CheckedDoubleSpec {
   object SmallerThan50 {
     type Cond[T] = T < W.`50.0`.T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Double) extends AnyVal with Checked0Param.Double.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Double) extends AnyVal with Checked0Param.Double.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Double = value
     }
-    object Check extends Checked0Param.Double.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Double.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -20,7 +20,7 @@ object CheckedDoubleSpec {
 class CheckedDoubleSpec extends Properties("Checked.Double") {
   import CheckedDoubleSpec._
 
-  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Checked[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40.0)

--- a/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
@@ -6,15 +6,21 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedFloatSpec {
-  type Cond[T] = T < W.`50.0f`.T
-  type Msg[T] = W.`"Failed Check"`.T
-  @checked0Param[Cond, Msg, Float] class CheckedSmallerThan50[T]
+  object SmallerThan50 {
+    type Cond[T] = T < W.`50.0f`.T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Float) extends AnyVal with Checked0Param.Float.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Float = value
+    }
+    object Check extends Checked0Param.Float.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedFloatSpec extends Properties("Checked.Float") {
   import CheckedFloatSpec._
 
-  def smallerThan50[T](t : CheckedSmallerThan50[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40.0f)

--- a/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
@@ -9,10 +9,10 @@ object CheckedFloatSpec {
   object SmallerThan50 {
     type Cond[T] = T < W.`50.0f`.T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Float) extends AnyVal with Checked0Param.Float.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Float) extends AnyVal with Checked0Param.Float.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Float = value
     }
-    object Check extends Checked0Param.Float.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Float.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -20,7 +20,7 @@ object CheckedFloatSpec {
 class CheckedFloatSpec extends Properties("Checked.Float") {
   import CheckedFloatSpec._
 
-  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Checked[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40.0f)

--- a/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedFloatSpec.scala
@@ -13,7 +13,7 @@ object CheckedFloatSpec {
       @inline def getValue : Float = value
     }
     object Checked extends Checked0Param.Float.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedIntSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedIntSpec.scala
@@ -9,10 +9,10 @@ object CheckedIntSpec {
   object SmallerThan50 {
     type Cond[T] = T < W.`50`.T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Int) extends AnyVal with Checked0Param.Int.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Int) extends AnyVal with Checked0Param.Int.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Int = value
     }
-    object Check extends Checked0Param.Int.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Int.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -21,20 +21,20 @@ class CheckedIntSpec extends Properties("Checked.Int") {
   import CheckedIntSpec._
 
   def foo[T](t : TwoFace.Int[T]) = t
-  def smallerThan50[T](t : SmallerThan50.Check[T]) = {
+  def smallerThan50[T](t : SmallerThan50.Checked[T]) = {
     val a : Int = t
     foo(t.unsafeCheck())
   }
 
 
   property("Compile-time checks") = wellTyped {
-    SmallerThan50.Check(5)
-    SmallerThan50.Check[W.`5`.T]
-    SmallerThan50.Check(TwoFace.Int(5))
-    val a = SmallerThan50.Check[W.`5`.T + W.`3`.T]
+    SmallerThan50.Checked(5)
+    SmallerThan50.Checked[W.`5`.T]
+    SmallerThan50.Checked(TwoFace.Int(5))
+    val a = SmallerThan50.Checked[W.`5`.T + W.`3`.T]
     implicitly[a.Out <:< W.`8`.T]
-    implicitly[SmallerThan50.Check[W.`5`.T]]
-    val b = implicitly[SmallerThan50.Check[W.`5`.T + W.`3`.T]]
+    implicitly[SmallerThan50.Checked[W.`5`.T]]
+    val b = implicitly[SmallerThan50.Checked[W.`5`.T + W.`3`.T]]
     implicitly[b.Out <:< (W.`5`.T + W.`3`.T)]
     val c = smallerThan50(40)
     implicitly[c.Out <:< W.`40`.T]
@@ -42,9 +42,9 @@ class CheckedIntSpec extends Properties("Checked.Int") {
     smallerThan50(TwoFace.Int[W.`30`.T])
     smallerThan50(implicitly[TwoFace.Int[W.`30`.T]])
 
-    illTyped("""SmallerThan50.Check(50)""" ,"Failed Check")
-    illTyped("""SmallerThan50.Check[W.`50`.T]""" ,"Failed Check")
-    illTyped("""SmallerThan50.Check[W.`49`.T + W.`3`.T]""" ,"Failed Check")
+    illTyped("""SmallerThan50.Checked(50)""" ,"Failed Check")
+    illTyped("""SmallerThan50.Checked[W.`50`.T]""" ,"Failed Check")
+    illTyped("""SmallerThan50.Checked[W.`49`.T + W.`3`.T]""" ,"Failed Check")
     illTyped("""smallerThan50(50)""" ,"Failed Check")
     illTyped("""smallerThan50(TwoFace.Int(50))""", "Failed Check")
   }

--- a/src/test/scala/singleton/twoface/CheckedIntSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedIntSpec.scala
@@ -13,7 +13,7 @@ object CheckedIntSpec {
       @inline def getValue : Int = value
     }
     object Checked extends Checked0Param.Int.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedIntSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedIntSpec.scala
@@ -6,32 +6,35 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedIntSpec {
-
-  type Cond[T] = T < W.`50`.T
-  type Msg[T] = W.`"Failed Check"`.T
-
-  @checked0Param[Cond, Msg, Int] class CheckedSmallerThan50[T]
-
+  object SmallerThan50 {
+    type Cond[T] = T < W.`50`.T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Int) extends AnyVal with Checked0Param.Int.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Int = value
+    }
+    object Check extends Checked0Param.Int.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedIntSpec extends Properties("Checked.Int") {
   import CheckedIntSpec._
 
   def foo[T](t : TwoFace.Int[T]) = t
-  def smallerThan50[T](t : CheckedSmallerThan50[T]) = {
+  def smallerThan50[T](t : SmallerThan50.Check[T]) = {
     val a : Int = t
     foo(t.unsafeCheck())
   }
 
 
   property("Compile-time checks") = wellTyped {
-    CheckedSmallerThan50(5)
-    CheckedSmallerThan50[W.`5`.T]
-    CheckedSmallerThan50(TwoFace.Int(5))
-    val a = CheckedSmallerThan50[W.`5`.T + W.`3`.T]
+    SmallerThan50.Check(5)
+    SmallerThan50.Check[W.`5`.T]
+    SmallerThan50.Check(TwoFace.Int(5))
+    val a = SmallerThan50.Check[W.`5`.T + W.`3`.T]
     implicitly[a.Out <:< W.`8`.T]
-    implicitly[CheckedSmallerThan50[W.`5`.T]]
-    val b = implicitly[CheckedSmallerThan50[W.`5`.T + W.`3`.T]]
+    implicitly[SmallerThan50.Check[W.`5`.T]]
+    val b = implicitly[SmallerThan50.Check[W.`5`.T + W.`3`.T]]
     implicitly[b.Out <:< (W.`5`.T + W.`3`.T)]
     val c = smallerThan50(40)
     implicitly[c.Out <:< W.`40`.T]
@@ -39,9 +42,9 @@ class CheckedIntSpec extends Properties("Checked.Int") {
     smallerThan50(TwoFace.Int[W.`30`.T])
     smallerThan50(implicitly[TwoFace.Int[W.`30`.T]])
 
-    illTyped("""CheckedSmallerThan50(50)""" ,"Failed Check")
-    illTyped("""CheckedSmallerThan50[W.`50`.T]""" ,"Failed Check")
-    illTyped("""CheckedSmallerThan50[W.`49`.T + W.`3`.T]""" ,"Failed Check")
+    illTyped("""SmallerThan50.Check(50)""" ,"Failed Check")
+    illTyped("""SmallerThan50.Check[W.`50`.T]""" ,"Failed Check")
+    illTyped("""SmallerThan50.Check[W.`49`.T + W.`3`.T]""" ,"Failed Check")
     illTyped("""smallerThan50(50)""" ,"Failed Check")
     illTyped("""smallerThan50(TwoFace.Int(50))""", "Failed Check")
   }

--- a/src/test/scala/singleton/twoface/CheckedLongSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedLongSpec.scala
@@ -9,10 +9,10 @@ object CheckedLongSpec {
   object SmallerThan50 {
     type Cond[T] = T < W.`50L`.T
     type Msg[T] = W.`"Failed Check"`.T
-    final class Check[T](val value : Long) extends AnyVal with Checked0Param.Long.CC[Check, Cond, Msg, T] {
+    final class Checked[T](val value : Long) extends AnyVal with Checked0Param.Long.CC[Checked, Cond, Msg, T] {
       @inline def getValue : Long = value
     }
-    object Check extends Checked0Param.Long.CO[Check, Cond, Msg]
+    object Checked extends Checked0Param.Long.CO[Checked, Cond, Msg]
     object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -20,7 +20,7 @@ object CheckedLongSpec {
 class CheckedLongSpec extends Properties("Checked.Long") {
   import CheckedLongSpec._
 
-  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Checked[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40L)

--- a/src/test/scala/singleton/twoface/CheckedLongSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedLongSpec.scala
@@ -6,15 +6,21 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedLongSpec {
-  type Cond[T] = T < W.`50L`.T
-  type Msg[T] = W.`"Failed Check"`.T
-  @checked0Param[Cond, Msg, Long] class CheckedSmallerThan50[T]
+  object SmallerThan50 {
+    type Cond[T] = T < W.`50L`.T
+    type Msg[T] = W.`"Failed Check"`.T
+    final class Check[T](val value : Long) extends AnyVal with Checked0Param.Long.CC[Check, Cond, Msg, T] {
+      @inline def getValue : Long = value
+    }
+    object Check extends Checked0Param.Long.CO[Check, Cond, Msg]
+    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedLongSpec extends Properties("Checked.Long") {
   import CheckedLongSpec._
 
-  def smallerThan50[T](t : CheckedSmallerThan50[T]) : Unit = {t.unsafeCheck()}
+  def smallerThan50[T](t : SmallerThan50.Check[T]) : Unit = {t.unsafeCheck()}
 
   property("Compile-time checks") = wellTyped {
     smallerThan50(40L)

--- a/src/test/scala/singleton/twoface/CheckedLongSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedLongSpec.scala
@@ -13,7 +13,7 @@ object CheckedLongSpec {
       @inline def getValue : Long = value
     }
     object Checked extends Checked0Param.Long.CO[Checked, Cond, Msg]
-    object WorkAround extends impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked0ParamAny.Builder[Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/src/test/scala/singleton/twoface/CheckedStringSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedStringSpec.scala
@@ -6,17 +6,23 @@ import singleton.TestUtils._
 import singleton.ops._
 
 object CheckedStringSpec {
-  type Cond[T, P] = Length[T] < P
-  type Msg[T, P] = W.`"Length of string '"`.T + T + W.`"' is not smaller than "`.T + ToString[P]
-  @checked1Param[Cond, Msg, String, Int] class CheckedLengthSmallerThan[T, P]
-  illTyped("""@checked1Param[Cond, Msg, String, Int] trait CheckedLengthSmallerThanBad[T, P]""")
+  object LengthSmallerThan {
+    type Cond[T, P] = Length[T] < P
+    type Msg[T, P] = W.`"Length of string '"`.T + T + W.`"' is not smaller than "`.T + ToString[P]
+    type ParamFace = Int
+    final class Check[T, Param](val value : String) extends AnyVal with Checked1Param.String.CC[Check, Cond, Msg, T, ParamFace, Param] {
+      @inline def getValue : String = value
+    }
+    object Check extends Checked1Param.String.CO[Check, Cond, Msg, ParamFace]
+    object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+  }
 }
 
 class CheckedStringSpec extends Properties("Checked.String") {
   import CheckedStringSpec._
 
   def foo[T](t : TwoFace.String[T]) : Unit = {}
-  def lengthSmallerThan5[T](t : CheckedLengthSmallerThan[T,W.`5`.T]) : Unit = {
+  def lengthSmallerThan5[T](t : LengthSmallerThan.Check[T,W.`5`.T]) : Unit = {
     val temp : String = t
     foo(t.unsafeCheck(5))
   }
@@ -24,12 +30,12 @@ class CheckedStringSpec extends Properties("Checked.String") {
   property("Compile-time checks") = wellTyped {
     lengthSmallerThan5("Hi")
     lengthSmallerThan5(TwoFace.String("Hi"))
-    CheckedLengthSmallerThan[W.`"Hi"`.T, W.`5`.T]
-    implicitly[CheckedLengthSmallerThan[W.`"Hi"`.T, W.`5`.T]]
+    LengthSmallerThan.Check[W.`"Hi"`.T, W.`5`.T]
+    implicitly[LengthSmallerThan.Check[W.`"Hi"`.T, W.`5`.T]]
     illTyped("""lengthSmallerThan5("Hello")""","Length of string 'Hello' is not smaller than 5")
     illTyped("""lengthSmallerThan5(TwoFace.String("Hello"))""","Length of string 'Hello' is not smaller than 5")
-    illTyped("""CheckedLengthSmallerThan[W.`"Hello"`.T, W.`5`.T]""","Length of string 'Hello' is not smaller than 5")
-    illTyped("""implicitly[CheckedLengthSmallerThan[W.`"Hello"`.T, W.`5`.T]]""","Length of string 'Hello' is not smaller than 5")
+    illTyped("""LengthSmallerThan.Check[W.`"Hello"`.T, W.`5`.T]""","Length of string 'Hello' is not smaller than 5")
+    illTyped("""implicitly[LengthSmallerThan.Check[W.`"Hello"`.T, W.`5`.T]]""","Length of string 'Hello' is not smaller than 5")
   }
 
   property("Run-time checks") = wellTyped {
@@ -39,7 +45,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
     illRun{lengthSmallerThan5(TwoFace.String(us("Hello")))}
   }
 
-  def lengthSmallerThan5Impl[T](realValue : String)(implicit t : CheckedLengthSmallerThan.Shell[T,W.`5`.T]) : Unit =
+  def lengthSmallerThan5Impl[T](realValue : String)(implicit t : LengthSmallerThan.Check.Shell[T,W.`5`.T]) : Unit =
     {t.unsafeCheck(realValue, 5)}
 
   property("Shell compile-time checks") = wellTyped {
@@ -54,7 +60,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
 
   trait CheckedUse[T]
   object CheckedUse {
-    implicit def ev[T](implicit checkedTrue: CheckedLengthSmallerThan.ShellSym[CheckedUse[_], T, W.`5`.T]) : CheckedUse[T] =
+    implicit def ev[T](implicit checkedTrue: LengthSmallerThan.Check.ShellSym[CheckedUse[_], T, W.`5`.T]) : CheckedUse[T] =
       new CheckedUse[T] {}
   }
 

--- a/src/test/scala/singleton/twoface/CheckedStringSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedStringSpec.scala
@@ -10,10 +10,10 @@ object CheckedStringSpec {
     type Cond[T, P] = Length[T] < P
     type Msg[T, P] = W.`"Length of string '"`.T + T + W.`"' is not smaller than "`.T + ToString[P]
     type ParamFace = Int
-    final class Check[T, Param](val value : String) extends AnyVal with Checked1Param.String.CC[Check, Cond, Msg, T, ParamFace, Param] {
+    final class Checked[T, Param](val value : String) extends AnyVal with Checked1Param.String.CC[Checked, Cond, Msg, T, ParamFace, Param] {
       @inline def getValue : String = value
     }
-    object Check extends Checked1Param.String.CO[Check, Cond, Msg, ParamFace]
+    object Checked extends Checked1Param.String.CO[Checked, Cond, Msg, ParamFace]
     object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   }
 }
@@ -22,7 +22,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
   import CheckedStringSpec._
 
   def foo[T](t : TwoFace.String[T]) : Unit = {}
-  def lengthSmallerThan5[T](t : LengthSmallerThan.Check[T,W.`5`.T]) : Unit = {
+  def lengthSmallerThan5[T](t : LengthSmallerThan.Checked[T,W.`5`.T]) : Unit = {
     val temp : String = t
     foo(t.unsafeCheck(5))
   }
@@ -30,12 +30,12 @@ class CheckedStringSpec extends Properties("Checked.String") {
   property("Compile-time checks") = wellTyped {
     lengthSmallerThan5("Hi")
     lengthSmallerThan5(TwoFace.String("Hi"))
-    LengthSmallerThan.Check[W.`"Hi"`.T, W.`5`.T]
-    implicitly[LengthSmallerThan.Check[W.`"Hi"`.T, W.`5`.T]]
+    LengthSmallerThan.Checked[W.`"Hi"`.T, W.`5`.T]
+    implicitly[LengthSmallerThan.Checked[W.`"Hi"`.T, W.`5`.T]]
     illTyped("""lengthSmallerThan5("Hello")""","Length of string 'Hello' is not smaller than 5")
     illTyped("""lengthSmallerThan5(TwoFace.String("Hello"))""","Length of string 'Hello' is not smaller than 5")
-    illTyped("""LengthSmallerThan.Check[W.`"Hello"`.T, W.`5`.T]""","Length of string 'Hello' is not smaller than 5")
-    illTyped("""implicitly[LengthSmallerThan.Check[W.`"Hello"`.T, W.`5`.T]]""","Length of string 'Hello' is not smaller than 5")
+    illTyped("""LengthSmallerThan.Checked[W.`"Hello"`.T, W.`5`.T]""","Length of string 'Hello' is not smaller than 5")
+    illTyped("""implicitly[LengthSmallerThan.Checked[W.`"Hello"`.T, W.`5`.T]]""","Length of string 'Hello' is not smaller than 5")
   }
 
   property("Run-time checks") = wellTyped {
@@ -45,7 +45,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
     illRun{lengthSmallerThan5(TwoFace.String(us("Hello")))}
   }
 
-  def lengthSmallerThan5Impl[T](realValue : String)(implicit t : LengthSmallerThan.Check.Shell[T,W.`5`.T]) : Unit =
+  def lengthSmallerThan5Impl[T](realValue : String)(implicit t : LengthSmallerThan.Checked.Shell[T,W.`5`.T]) : Unit =
     {t.unsafeCheck(realValue, 5)}
 
   property("Shell compile-time checks") = wellTyped {
@@ -60,7 +60,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
 
   trait CheckedUse[T]
   object CheckedUse {
-    implicit def ev[T](implicit checkedTrue: LengthSmallerThan.Check.ShellSym[CheckedUse[_], T, W.`5`.T]) : CheckedUse[T] =
+    implicit def ev[T](implicit checkedTrue: LengthSmallerThan.Checked.ShellSym[CheckedUse[_], T, W.`5`.T]) : CheckedUse[T] =
       new CheckedUse[T] {}
   }
 

--- a/src/test/scala/singleton/twoface/CheckedStringSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedStringSpec.scala
@@ -14,7 +14,7 @@ object CheckedStringSpec {
       @inline def getValue : String = value
     }
     object Checked extends Checked1Param.String.CO[Checked, Cond, Msg, ParamFace]
-    object WorkAround extends impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
+    object WorkAround extends singleton.twoface.impl.Checked1ParamAny.Builder[Nothing, Nothing, Nothing, Nothing, Nothing]
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-SNAPSHOT"
+version in ThisBuild := "0.2.4-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.4-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
This PR removes the meta macro annotations that were used to minimize new `Checked` types generation. 
Because macro annotation were deprecated, it is best to remove their dependency.