### PR TITLE
Added implicit widening for TwoFace and Checked

### DIFF
--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -1395,7 +1395,7 @@ trait GeneralMacros {
 //      print(genTree)
       genTree
     }
-    def toNumValue[Out](tfTree : c.Tree, tfSym : TypeSymbol, tTpe : Type) : c.Tree = {
+    def toNumValue(tfTree : c.Tree, tfSym : TypeSymbol, tTpe : Type) : c.Tree = {
       implicit val annotatedSym : TypeSymbol = tfSym
       val calc = extractValueFromTwoFaceTree(tfTree)
       val outTpe = calc.tpe
@@ -1485,6 +1485,13 @@ trait GeneralMacros {
 //      print(genTree)
       genTree
     }
+    def widen(chkTree : c.Tree) : c.Tree = {
+      implicit val annotatedSym : TypeSymbol = chkSym
+      val tfValueCalc = extractValueFromTwoFaceTree(chkTree)
+      val genTree = newChecked(tfValueCalc, tTpe)
+      //      print(genTree)
+      genTree
+    }
   }
   ///////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1547,6 +1554,14 @@ trait GeneralMacros {
       val paramCalc = extractValueFromOpTree(paramOpTree)
       val genTree = newChecked(tCalc, paramCalc)
 //      print(genTree)
+      genTree
+    }
+    def widen(tTFTree : c.Tree, paramOpTree : c.Tree) : c.Tree = {
+      implicit val annotatedSym : TypeSymbol = chkSym
+      val tCalc = extractValueFromTwoFaceTree(tTFTree)
+      val paramCalc = extractValueFromOpTree(paramOpTree)
+      val genTree = newChecked(tCalc, tTpe, paramCalc, paramTpe)
+      //      print(genTree)
       genTree
     }
   }

--- a/src/main/scala/singleton/twoface/impl/Checked0ParamAny.scala
+++ b/src/main/scala/singleton/twoface/impl/Checked0ParamAny.scala
@@ -36,6 +36,9 @@ object Checked0ParamAny {
 
     implicit def fromTF[Cond[_], Msg[_], T >: Face, Out <: T](value : TwoFaceAny[Face, T])
     : Chk[Cond, Msg, Out] = macro Builder.Macro.fromTF[Chk[Cond,Msg,_], Cond[_], Msg[_], T]
+
+    implicit def widen[Cond[_], Msg[_], T](value : Chk[Cond, Msg, T])
+    : Chk[Cond, Msg, Face] = macro Builder.Macro.widen[Chk[Cond,Msg,_], Cond[_], Msg[_], Face]
     ////////////////////////////////////////////////////////////////////////////////////////
   }
 
@@ -56,6 +59,11 @@ object Checked0ParamAny {
         implicit
         chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
       ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].fromTF(value)
+
+      def widen[Chk, Cond, Msg, T](value : c.Tree)(
+        implicit
+        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
+      ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].widen(value)
     }
   }
 

--- a/src/main/scala/singleton/twoface/impl/Checked1ParamAny.scala
+++ b/src/main/scala/singleton/twoface/impl/Checked1ParamAny.scala
@@ -38,6 +38,9 @@ object Checked1ParamAny {
 
     implicit def fromTF[Cond[_,_], Msg[_,_], T >: Face, ParamFace, Param, Out <: T](value : TwoFaceAny[Face, T])(implicit param : AcceptNonLiteral[Id[Param]])
     : Chk[Cond, Msg, Out, ParamFace, Param] = macro Builder.Macro.fromTF[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param]
+
+    implicit def widen[Cond[_,_], Msg[_,_], T, ParamFace, Param](value : Chk[Cond, Msg, T, ParamFace, Param])(implicit param : AcceptNonLiteral[Id[Param]])
+    : Chk[Cond, Msg, Face, ParamFace, Param] = macro Builder.Macro.widen[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], Face, ParamFace, Param]
     ////////////////////////////////////////////////////////////////////////////////////////
   }
 
@@ -58,6 +61,11 @@ object Checked1ParamAny {
         implicit
         chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
       ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].fromTF(value, param)
+
+      def widen[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(param : c.Tree)(
+        implicit
+        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
+      ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].widen(value, param)
     }
   }
 

--- a/src/main/scala/singleton/twoface/impl/TwoFaceAny.scala
+++ b/src/main/scala/singleton/twoface/impl/TwoFaceAny.scala
@@ -191,6 +191,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Char[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Char])
     implicit def apply[T <: std.Char, Out <: T](value : T) : Char[Out] = macro Builder.Macro.fromNumValue[Char[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Char[T] = create[T](id.valueWide.asInstanceOf[std.Char])
+    implicit def widen[T](tf : Char[T]) : Char[std.Char] = create[std.Char](tf.getValue)
     implicit def tf2Num[T <: std.Char](tf : Char[T]) : T = macro Builder.Macro.toNumValue[Char[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Char](tf : Char[T])(implicit id : OpAuxChar[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Char[_], Out]
     implicit def unsafeTF2Num(tf : Char[_]) : std.Char = macro Builder.Macro.toNumValue[Char[_], std.Char]
@@ -304,6 +305,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Int[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Int])
     implicit def apply[T <: std.Int, Out <: T](value : T) : Int[Out] = macro Builder.Macro.fromNumValue[Int[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Int[T] = create[T](id.valueWide.asInstanceOf[std.Int])
+    implicit def widen[T](tf : Int[T]) : Int[std.Int] = create[std.Int](tf.getValue)
     implicit def tf2Num[T <: std.Int](tf : Int[T]) : T = macro Builder.Macro.toNumValue[Int[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Int](tf : Int[T])(implicit id : OpAuxInt[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Int[_], Out]
     implicit def unsafeTF2Num(tf : Int[_]) : std.Int = macro Builder.Macro.toNumValue[Int[_], std.Int]
@@ -418,6 +420,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Long[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Long])
     implicit def apply[T <: std.Long, Out <: T](value : T) : Long[Out] = macro Builder.Macro.fromNumValue[Long[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Long[T] = create[T](id.valueWide.asInstanceOf[std.Long])
+    implicit def widen[T](tf : Long[T]) : Long[std.Long] = create[std.Long](tf.getValue)
     implicit def tf2Num[T <: std.Long](tf : Long[T]) : T = macro Builder.Macro.toNumValue[Long[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Long](tf : Long[T])(implicit id : OpAuxLong[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Long[_], Out]
     implicit def unsafeTF2Num(tf : Long[_]) : std.Long = macro Builder.Macro.toNumValue[Long[_], std.Long]
@@ -530,6 +533,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Float[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Float])
     implicit def apply[T <: std.Float, Out <: T](value : T) : Float[Out] = macro Builder.Macro.fromNumValue[Float[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Float[T] = create[T](id.valueWide.asInstanceOf[std.Float])
+    implicit def widen[T](tf : Float[T]) : Float[std.Float] = create[std.Float](tf.getValue)
     implicit def tf2Num[T <: std.Float](tf : Float[T]) : T = macro Builder.Macro.toNumValue[Float[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Float](tf : Float[T])(implicit id : OpAuxFloat[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Float[_], Out]
     implicit def unsafeTF2Num(tf : Float[_]) : std.Float = macro Builder.Macro.toNumValue[Float[_], std.Float]
@@ -642,6 +646,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Double[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Double])
     implicit def apply[T <: std.Double, Out <: T](value : T) : Double[Out] = macro Builder.Macro.fromNumValue[Double[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Double[T] = create[T](id.valueWide.asInstanceOf[std.Double])
+    implicit def widen[T](tf : Double[T]) : Double[std.Double] = create[std.Double](tf.getValue)
     implicit def tf2Num[T <: std.Double](tf : Double[T]) : T = macro Builder.Macro.toNumValue[Double[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Double](tf : Double[T])(implicit id : OpAuxDouble[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Double[_], Out]
     implicit def unsafeTF2Num(tf : Double[_]) : std.Double = macro Builder.Macro.toNumValue[Double[_], std.Double]
@@ -679,6 +684,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : String[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.String])
     implicit def apply[T <: std.String, Out <: T](value : T) : String[Out] = macro Builder.Macro.fromNumValue[String[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : String[T] = create[T](id.valueWide.asInstanceOf[std.String])
+    implicit def widen[T](tf : String[T]) : String[std.String] = create[std.String](tf.getValue)
     implicit def tf2Num[T <: std.String](tf : String[T]) : T = macro Builder.Macro.toNumValue[String[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.String](tf : String[T])(implicit id : OpAuxString[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[String[_], Out]
     implicit def unsafeTF2Num(tf : String[_]) : std.String = macro Builder.Macro.toNumValue[String[_], std.String]
@@ -709,6 +715,7 @@ object TwoFaceAny {
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Boolean[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Boolean])
     implicit def apply[T <: std.Boolean, Out <: T](value : T) : Boolean[Out] = macro Builder.Macro.fromNumValue[Boolean[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Boolean[T] = create[T](id.valueWide.asInstanceOf[std.Boolean])
+    implicit def widen[T](tf : Boolean[T]) : Boolean[std.Boolean] = create[std.Boolean](tf.getValue)
     implicit def tf2Num[T <: std.Boolean](tf : Boolean[T]) : T = macro Builder.Macro.toNumValue[Boolean[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Boolean](tf : Boolean[T])(implicit id : OpAuxBoolean[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Boolean[_], Out]
     implicit def unsafeTF2Num(tf : Boolean[_]) : std.Boolean = macro Builder.Macro.toNumValue[Boolean[_], std.Boolean]

--- a/src/test/scala/singleton/twoface/CheckedIntSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedIntSpec.scala
@@ -20,6 +20,12 @@ class CheckedIntSpec extends Properties("Checked.Int") {
     val a : Int = t
     foo(t.unsafeCheck())
   }
+  def smallerThan50Seq(tSeq : SmallerThan50.Checked[Int]*) = {
+    for (t <- tSeq) {
+      val a : Int = t
+      foo(t.unsafeCheck())
+    }
+  }
 
   property("Compile-time checks") = wellTyped {
     implicitly[SmallerThan50.Checked[W.`5`.T]]
@@ -30,15 +36,23 @@ class CheckedIntSpec extends Properties("Checked.Int") {
     smallerThan50(TwoFace.Int(40))
     smallerThan50(TwoFace.Int[W.`30`.T])
     smallerThan50(implicitly[TwoFace.Int[W.`30`.T]])
+    smallerThan50Seq(1,2,3)
+    val widen : SmallerThan50.Checked[Int] = 5
     illTyped("""smallerThan50(50)""" ,"Failed Check")
     illTyped("""smallerThan50(TwoFace.Int(50))""", "Failed Check")
     illTyped("""implicitly[SmallerThan50.Checked[W.`60`.T]]""", "Failed Check")
+    illTyped("""val widen2 : SmallerThan50.Checked[Int] = 50""" ,"Failed Check")
+    illTyped("""smallerThan50Seq(1,us(70),60)""","Failed Check")
   }
 
   property("Run-time checks") = wellTyped {
+    smallerThan50Seq(us(1),2,3)
     smallerThan50(us(40))
     smallerThan50(TwoFace.Int(us(40)))
+    val us70 = 70
+    val us60 = 60
     illRun{smallerThan50(us(50))}
     illRun{smallerThan50(TwoFace.Int(us(50)))}
+    illRun{smallerThan50Seq(1,us70,us60)}
   }
 }

--- a/src/test/scala/singleton/twoface/CheckedStringSpec.scala
+++ b/src/test/scala/singleton/twoface/CheckedStringSpec.scala
@@ -21,21 +21,32 @@ class CheckedStringSpec extends Properties("Checked.String") {
     val temp : String = t
     foo(t.unsafeCheck(5))
   }
+  def lengthSmallerThan5Seq(tSeq : LengthSmallerThan.Checked[String,W.`5`.T]*) : Unit = {
+    for (t <- tSeq) {
+      val temp : String = t
+      foo(t.unsafeCheck(5))
+    }
+  }
 
   property("Compile-time checks") = wellTyped {
     lengthSmallerThan5("Hi")
     lengthSmallerThan5(TwoFace.String("Hi"))
     implicitly[LengthSmallerThan.Checked[W.`"Hi"`.T,W.`5`.T]]
+    lengthSmallerThan5Seq("Hi", "Hey")
     illTyped("""lengthSmallerThan5("Hello")""","Length of string 'Hello' is not smaller than 5")
     illTyped("""lengthSmallerThan5(TwoFace.String("Hello"))""","Length of string 'Hello' is not smaller than 5")
     illTyped("""implicitly[LengthSmallerThan.Checked[W.`"Hello"`.T,W.`5`.T]]""","Length of string 'Hello' is not smaller than 5")
+    illTyped("""lengthSmallerThan5Seq("Hi", "Hey", "Hello")""","Length of string 'Hello' is not smaller than 5")
   }
 
   property("Run-time checks") = wellTyped {
     lengthSmallerThan5(us("Hi"))
     lengthSmallerThan5(TwoFace.String(us("Hi")))
+    lengthSmallerThan5Seq(us("Hi"), "Hey")
     illRun{lengthSmallerThan5(us("Hello"))}
     illRun{lengthSmallerThan5(TwoFace.String(us("Hello")))}
+    val usHello = "Hello"
+    illRun{lengthSmallerThan5Seq(us("Hi"), "Hey", usHello)}
   }
 
   def lengthSmallerThan5Impl[T](realValue : String)(implicit t : LengthSmallerThan.CheckedShell[T,W.`5`.T]) : Unit =

--- a/src/test/scala/singleton/twoface/TwoFaceBooleanSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceBooleanSpec.scala
@@ -81,6 +81,7 @@ class TwoFaceBooleanSpec extends Properties("TwoFace.Boolean") {
     val c : TwoFace.Boolean[W.`true`.T && W.`true`.T] = implicitly[TwoFace.Boolean[W.`true`.T]]
     val d : W.`true`.T = TwoFace.Boolean(true)
     val e : Boolean = TwoFace.Boolean(us(false))
+    val f : TwoFace.Boolean[Boolean] = false
   }
 
   property("Wrong Implicit Conversions") = wellTyped {

--- a/src/test/scala/singleton/twoface/TwoFaceCharSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceCharSpec.scala
@@ -323,6 +323,7 @@ class TwoFaceCharSpec extends Properties("TwoFace.Char") {
   property("Implicit Conversions") = wellTyped {
     val d : W.`'\u0003'`.T = TwoFace.Char('\u0003')
     val e : Char = TwoFace.Char(us('\u0003'))
+    val f : TwoFace.Char[Char] = '\u0003'
   }
 
   property("ToString") = {

--- a/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceDoubleSpec.scala
@@ -372,6 +372,7 @@ class TwoFaceDoubleSpec extends Properties("TwoFace.Double") {
     val c : TwoFace.Double[W.`3.0`.T + W.`0.0`.T] = implicitly[TwoFace.Double[W.`3.0`.T]]
     val d : W.`3.0`.T = TwoFace.Double(3.0)
     val e : Double = TwoFace.Double(us(3.0))
+    val f : TwoFace.Double[Double] = 3.0
   }
 
   property("Wrong Implicit Conversions") = wellTyped {

--- a/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceFloatSpec.scala
@@ -369,6 +369,7 @@ class TwoFaceFloatSpec extends Properties("TwoFace.Float") {
     val c : TwoFace.Float[W.`3.0f`.T + W.`0.0f`.T] = implicitly[TwoFace.Float[W.`3.0f`.T]]
     val d : W.`3.0f`.T = TwoFace.Float(3.0f)
     val e : Float = TwoFace.Float(us(3.0f))
+    val f : TwoFace.Float[Float] = 3.0f
   }
 
   property("Wrong Implicit Conversions") = wellTyped {

--- a/src/test/scala/singleton/twoface/TwoFaceIntSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceIntSpec.scala
@@ -351,6 +351,11 @@ class TwoFaceIntSpec extends Properties("TwoFace.Int") {
     val conv9 : TwoFace.Int[W.`3`.T + W.`0`.T] = implicitly[TwoFace.Int[W.`3`.T]]
     val conv10 : Int = TwoFace.Int(us(3))
     val conv11 : W.`3`.T = implicitly[TwoFace.Int[Id[W.`3`.T]]]
+    //widening
+    val conv12 : TwoFace.Int[Int] = 3
+    val conv13 : TwoFace.Int[Int] = TwoFace.Int[W.`3`.T]
+    val conv14 : TwoFace.Int[Int] = TwoFace.Int(3)
+    val conv15 : TwoFace.Int[Int] = implicitly[TwoFace.Int[W.`3`.T]]
   }
 
   property("Wrong Implicit Conversions") = wellTyped {

--- a/src/test/scala/singleton/twoface/TwoFaceLongSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceLongSpec.scala
@@ -344,6 +344,7 @@ class TwoFaceLongSpec extends Properties("TwoFace.Long") {
     val c : TwoFace.Long[W.`3L`.T + W.`0L`.T] = implicitly[TwoFace.Long[W.`3L`.T]]
     val d : W.`3L`.T = TwoFace.Long(3L)
     val e : Long = TwoFace.Long(us(3L))
+    val f : TwoFace.Long[Long] = 3L
   }
 
   property("Wrong Implicit Conversions") = wellTyped {

--- a/src/test/scala/singleton/twoface/TwoFaceStringSpec.scala
+++ b/src/test/scala/singleton/twoface/TwoFaceStringSpec.scala
@@ -90,6 +90,7 @@ class TwoFaceStringSpec extends Properties("TwoFace.String") {
     val c : TwoFace.String[W.`"Some"`.T + W.`"thing"`.T] = implicitly[TwoFace.String[W.`"Something"`.T]]
     val d : W.`"Some"`.T = TwoFace.String("Some")
     val e : String = TwoFace.String(us("Some"))
+    val f : TwoFace.String[String] = "Some"
   }
 
   property("Wrong Implicit Conversions") = wellTyped {


### PR DESCRIPTION
For example, this PR enables any `TwoFace.Int[T]` to be implicitly converted into `TwoFace.Int[Int]`.