### PR TITLE
Added `GetImplicitArgType` to get an implicit conversion argument

### DIFF
--- a/src/main/scala/singleton/ops/impl/OpId.scala
+++ b/src/main/scala/singleton/ops/impl/OpId.scala
@@ -4,6 +4,7 @@ sealed trait OpId
 object OpId {
   sealed trait Arg extends OpId //Argument
   sealed trait AcceptNonLiteral extends OpId
+  sealed trait GetImplicitArgType extends OpId
   sealed trait ITE extends OpId //If-Then-Else
   sealed trait ==> extends OpId
   sealed trait Id extends OpId

--- a/src/main/scala/singleton/ops/package.scala
+++ b/src/main/scala/singleton/ops/package.scala
@@ -72,6 +72,8 @@ package object ops {
   protected[singleton] type Arg[Num, T, TWide] = OpMacro[OpId.Arg, Num, T, TWide] //Argument for real-time function creation
   protected[singleton] type GetType[Sym] = OpMacro[OpId.GetType, Sym, NP, NP] //Argument for real-time function creation
   type AcceptNonLiteral[P1] = OpMacro[OpId.AcceptNonLiteral, P1, NP, NP]
+  type GetImplicitArgType[ArgIdx] = OpMacro[OpId.GetImplicitArgType, ArgIdx, NP, NP] //Use to get argument type of an implicit conversion
+  type GIAT0                = GetImplicitArgType[W.`0`.T]
   type Id[P1]               = OpMacro[OpId.Id, P1, NP, NP]
   type ![P1]                = OpMacro[OpId.!, P1, NP, NP]
   type Require[Cond]        = OpMacro[OpId.Require, Cond, DefaultRequireMsg, NP]
@@ -232,5 +234,4 @@ package object ops {
       ]
    ) : C[T1, T2, T3] = ct
   /////////////////////////////////////////////////
-
 }

--- a/src/test/scala/singleton/ops/GIATSpec.scala
+++ b/src/test/scala/singleton/ops/GIATSpec.scala
@@ -8,9 +8,8 @@ class GIATSpec extends Properties("GIATSpec") {
   trait Conv {
     val value : Any
   }
-  type CheckSmallThan50 = CompileTime[GIAT0 < W.`50`.T]
 
-  implicit class ConvInt(val value : Int)(implicit chk : CheckSmallThan50) extends Conv
+  implicit class ConvInt(val value : Int)(implicit chk : CompileTime[GIAT0 < W.`50`.T]) extends Conv
   def smallerThan50(f : Conv) : Unit = {}
 
   implicit class BadConvLong(val value : Long)(implicit f : GetImplicitArgType[W.`10`.T]) extends Conv
@@ -20,6 +19,7 @@ class GIATSpec extends Properties("GIATSpec") {
     smallerThan50(1)
   }
   property("smallerThan50(51) Compile-time fail") = wellTyped {
+    illTyped("smallerThan50(51)")
   }
   property("Unsupported") = wellTyped {
     illTyped("implicitly[GIAT0]") //cannot be invoked without implicit conversion

--- a/src/test/scala/singleton/ops/GIATSpec.scala
+++ b/src/test/scala/singleton/ops/GIATSpec.scala
@@ -1,0 +1,29 @@
+package singleton.ops
+
+import org.scalacheck.Properties
+import shapeless.test.illTyped
+import singleton.TestUtils._
+
+class GIATSpec extends Properties("GIATSpec") {
+  trait Conv {
+    val value : Any
+  }
+  type CheckSmallThan50 = CompileTime[GIAT0 < W.`50`.T]
+
+  implicit class ConvInt(val value : Int)(implicit chk : CheckSmallThan50) extends Conv
+  def smallerThan50(f : Conv) : Unit = {}
+
+  implicit class BadConvLong(val value : Long)(implicit f : GetImplicitArgType[W.`10`.T]) extends Conv
+
+
+  property("smallerThan50(1) OK") = wellTyped {
+    smallerThan50(1)
+  }
+  property("smallerThan50(51) Compile-time fail") = wellTyped {
+  }
+  property("Unsupported") = wellTyped {
+    illTyped("implicitly[GIAT0]") //cannot be invoked without implicit conversion
+    illTyped("smallerThan50(1L)") //Argument index too large in `BadConvLong`
+    illTyped("implicitly[GetImplicitArgType[W.`0.1`.T]]") //Bad argument (Double instead of Int)
+  }
+}


### PR DESCRIPTION
Implicit conversion in Scala is automatically widening types in case of failure. E.g.,
```scala
  trait Conv {
    val value : Any
  }
  type CheckSmallThan50[T] = CompileTime[T < 50]

  implicit class ConvXInt[R <: XInt](val value : R)(implicit chk : CheckSmallThan50[R]) extends Conv
  implicit class ConvInt(val value : Int) extends Conv
  def smallerThan50(f : Conv) : Unit = {}

  smallerThan50(51) //succeeds :(
```
To overcome this, `GetImplicitArgType` was added which retrieves the narrow type from the implicit argument's tree. E.g.,
```scala
  trait Conv {
    val value : Any
  }
  type CheckSmallThan50 = CompileTime[GIAT0 < 50] //GIAT0 is GetImplicitArgType[0]

  implicit class ConvInt(val value : Int)(implicit chk : CheckSmallThan50) extends Conv
  def smallerThan50(f : Conv) : Unit = {}

  val one = 1
  smallerThan50(1) //succeeds :)
  smallerThan50(one) //succeeds (postpone to run-time check)
  smallerThan50(51) //fails as expected :)
```

