### PR TITLE
Added GetLHSArg

### DIFF
--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -753,15 +753,16 @@ trait GeneralMacros {
 
     def getAllLHSArgs(tree : Tree)(implicit annotatedSym : TypeSymbol) : List[Tree] = tree match {
       case Apply(TypeApply(Select(t, _), _), _) => getAllArgs(t, true)
+      case Select(t, _) => getAllArgs(t, true)
       case _ => abort("Left-hand-side tree not found")
     }
 
     def apply(argIdx : Int, lhs : Boolean)(implicit annotatedSym : TypeSymbol) : c.Tree = {
       val tree = c.enclosingImplicits.last.tree
-      val allArgs = if (lhs) getAllLHSArgs(tree) else getAllArgs(tree, lhs)
 //      print(">>>>>>> enclosingImpl: " + c.enclosingImplicits.last)
 //      print("tree: " + c.enclosingImplicits.last.tree)
 //      print("rawTree: " + showRaw(c.enclosingImplicits.last.tree))
+      val allArgs = if (lhs) getAllLHSArgs(tree) else getAllArgs(tree, lhs)
 //      print("args: " + allArgs)
 //      print("<<<<<<< rawArgs" + showRaw(allArgs))
       if (argIdx < allArgs.length) allArgs(argIdx)

--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -15,6 +15,7 @@ trait GeneralMacros {
     val Arg = symbolOf[OpId.Arg]
     val AcceptNonLiteral = symbolOf[OpId.AcceptNonLiteral]
     val GetArg = symbolOf[OpId.GetArg]
+    val GetLHSArg = symbolOf[OpId.GetLHSArg]
     val Id = symbolOf[OpId.Id]
     val ToNat = symbolOf[OpId.ToNat]
     val ToChar = symbolOf[OpId.ToChar]
@@ -715,54 +716,61 @@ trait GeneralMacros {
   ///////////////////////////////////////////////////////////////////////////////////////////
   // Get Argument
   ///////////////////////////////////////////////////////////////////////////////////////////
-  def materializeGetArg(gaSym : TypeSymbol, auxSym : TypeSymbol, aiTpe : Type) : c.Tree = {
-    implicit val annotatedSym : TypeSymbol = auxSym
-    val argIdx : Int = TypeCalc(aiTpe) match {
-      case CalcLit.Int(t) => t
-      case _ => abort(s"Invalid argument index. Found $aiTpe")
-    }
-    val valueTree : Tree = getArgTree(argIdx)
-    val outTpe : Type = c.typecheck(valueTree).tpe
+  object MaterializeGetArg {
+    def apply(gaSym : TypeSymbol, auxSym : TypeSymbol, aiTpe : Type, lhs : Boolean) : c.Tree = {
+      implicit val annotatedSym : TypeSymbol = auxSym
+      val argIdx : Int = TypeCalc(aiTpe) match {
+        case CalcLit.Int(t) => t
+        case _ => abort(s"Invalid argument index. Found $aiTpe")
+      }
+      val valueTree : Tree = GetArgTree(argIdx, lhs)
+      val outTpe : Type = c.typecheck(valueTree).tpe
 
-    val genTree = q"""
+      val genTree = q"""
         new $gaSym[$aiTpe]{
           type Out = $outTpe
           val value : Out = $valueTree
         }
      """
-//    print(genTree)
-    genTree
+      //    print(genTree)
+      genTree
+    }
   }
 
-  def getArgTree(argIdx : Int)(implicit annotatedSym : TypeSymbol) : c.Tree = {
+  object GetArgTree {
     def isMethodMacroCall : Boolean = c.enclosingImplicits.last.sym.isMacro
-    def getAllArgs(tree : Tree) : List[Tree] = {
-      tree match {
-        case Apply(Select(q,n), args) => if (isMethodMacroCall) args else List(tree)
-        case t : Select => List(t)
-        case t : Literal => List(t)
-        case _ => getAllArgsRecur(tree)
-      }
+    def getAllArgs(tree : Tree, lhs : Boolean) : List[Tree] = tree match {
+      case Apply(Select(q,n), args) => if (isMethodMacroCall || lhs) args else List(tree)
+      case t : Select => List(t)
+      case t : Literal => List(t)
+      case _ => getAllArgsRecur(tree)
+    }
 
+    def getAllArgsRecur(tree : Tree) : List[Tree] = tree match {
+      case Apply(fun, args) => getAllArgsRecur(fun) ++ args
+      case _ => List()
     }
-    def getAllArgsRecur(tree : Tree) : List[Tree] = {
-      tree match {
-        case Apply(fun, args) => getAllArgsRecur(fun) ++ args
-        case _ => List()
-      }
+
+    def getAllLHSArgs(tree : Tree)(implicit annotatedSym : TypeSymbol) : List[Tree] = tree match {
+      case Apply(TypeApply(Select(t, _), _), _) => getAllArgs(t, true)
+      case _ => abort("Left-hand-side tree not found")
     }
-    val allArgs = getAllArgs(c.enclosingImplicits.last.tree)
-//    print("enclosingImpl:" + c.enclosingImplicits.last)
-//    print("tree:" + c.enclosingImplicits.last.tree)
-//    print("rawTree:" + showRaw(c.enclosingImplicits.last.tree))
-//    print("args" + allArgs)
-//    print("rawArgs" + showRaw(allArgs))
-    if (argIdx < allArgs.length) allArgs(argIdx)
-    else abort(s"Argument index($argIdx) is not smaller than the total number of arguments(${allArgs.length})")
+
+    def apply(argIdx : Int, lhs : Boolean)(implicit annotatedSym : TypeSymbol) : c.Tree = {
+      val tree = c.enclosingImplicits.last.tree
+      val allArgs = if (lhs) getAllLHSArgs(tree) else getAllArgs(tree, lhs)
+//      print(">>>>>>> enclosingImpl: " + c.enclosingImplicits.last)
+//      print("tree: " + c.enclosingImplicits.last.tree)
+//      print("rawTree: " + showRaw(c.enclosingImplicits.last.tree))
+//      print("args: " + allArgs)
+//      print("<<<<<<< rawArgs" + showRaw(allArgs))
+      if (argIdx < allArgs.length) allArgs(argIdx)
+      else abort(s"Argument index($argIdx) is not smaller than the total number of arguments(${allArgs.length})")
+    }
   }
 
-  def extractFromArg(argIdx : Int)(implicit annotatedSym : TypeSymbol) : CalcVal = {
-    extractValueFromNumTree(getArgTree(argIdx))
+  def extractFromArg(argIdx : Int, lhs : Boolean)(implicit annotatedSym : TypeSymbol) : CalcVal = {
+    extractValueFromNumTree(GetArgTree(argIdx, lhs))
   }
   ///////////////////////////////////////////////////////////////////////////////////////////
 
@@ -783,7 +791,11 @@ trait GeneralMacros {
 
     def AcceptNonLiteral = a
     def GetArg = a match {
-      case CalcLit.Int(t) if (t >= 0) => extractFromArg(t)
+      case CalcLit.Int(t) if (t >= 0) => extractFromArg(t, false)
+      case _ => unsupported()
+    }
+    def GetLHSArg = a match {
+      case CalcLit.Int(t) if (t >= 0) => extractFromArg(t, true)
       case _ => unsupported()
     }
     def Id = a
@@ -1093,6 +1105,7 @@ trait GeneralMacros {
     funcType match {
       case funcTypes.AcceptNonLiteral => AcceptNonLiteral
       case funcTypes.GetArg => GetArg
+      case funcTypes.GetLHSArg => GetLHSArg
       case funcTypes.Id => Id
       case funcTypes.ToNat => ToNat
       case funcTypes.ToChar => ToChar

--- a/src/main/scala/singleton/ops/impl/OpId.scala
+++ b/src/main/scala/singleton/ops/impl/OpId.scala
@@ -5,6 +5,7 @@ object OpId {
   sealed trait Arg extends OpId //Argument
   sealed trait AcceptNonLiteral extends OpId
   sealed trait GetArg extends OpId
+  sealed trait GetLHSArg extends OpId
   sealed trait ITE extends OpId //If-Then-Else
   sealed trait ==> extends OpId
   sealed trait Id extends OpId

--- a/src/main/scala/singleton/ops/impl/OpMacros.scala
+++ b/src/main/scala/singleton/ops/impl/OpMacros.scala
@@ -108,7 +108,33 @@ object GetArg {
 
     final class Macro(val c: whitebox.Context) extends GeneralMacros {
       def impl[ArgIdx : c.WeakTypeTag]: c.Tree =
-        materializeGetArg(c.symbolOf[GetArg[_]], c.symbolOf[Aux[_,_]], c.weakTypeOf[ArgIdx])
+        MaterializeGetArg(c.symbolOf[GetArg[_]], c.symbolOf[Aux[_,_]], c.weakTypeOf[ArgIdx], false)
+    }
+    implicit def toArgValue[I, Out](i : Aux[I, Out]) : Out = i.value
+  }
+}
+/*******************************************************************************************************/
+
+
+/********************************************************************************************************
+  * Get function/class argument's type
+  *******************************************************************************************************/
+object GetLHSArg {
+  type Aux[ArgIdx, Out0] = GetLHSArg[ArgIdx]{type Out = Out0}
+
+  @scala.annotation.implicitNotFound("Argument with index ${ArgIdx} not found")
+  trait GetLHSArg[ArgIdx] {
+    type Out
+    val value : Out
+  }
+
+  @ bundle
+  object GetLHSArg {
+    implicit def call[ArgIdx, Out]: Aux[ArgIdx, Out] = macro Macro.impl[ArgIdx]
+
+    final class Macro(val c: whitebox.Context) extends GeneralMacros {
+      def impl[ArgIdx : c.WeakTypeTag]: c.Tree =
+        MaterializeGetArg(c.symbolOf[GetLHSArg[_]], c.symbolOf[Aux[_,_]], c.weakTypeOf[ArgIdx], true)
     }
     implicit def toArgValue[I, Out](i : Aux[I, Out]) : Out = i.value
   }

--- a/src/main/scala/singleton/ops/package.scala
+++ b/src/main/scala/singleton/ops/package.scala
@@ -72,9 +72,12 @@ package object ops {
   protected[singleton] type Arg[Num, T, TWide] = OpMacro[OpId.Arg, Num, T, TWide] //Argument for real-time function creation
   protected[singleton] type GetType[Sym] = OpMacro[OpId.GetType, Sym, NP, NP] //Argument for real-time function creation
   type AcceptNonLiteral[P1] = OpMacro[OpId.AcceptNonLiteral, P1, NP, NP]
-  type GetArg[ArgIdx]       = OpMacro[OpId.GetArg, ArgIdx, NP, NP] //Use to get argument type of an implicit conversion
-  val  GetArg               = impl.GetArg
+  type GetArg[ArgIdx]       = OpMacro[OpId.GetArg, ArgIdx, NP, NP] //Use to get argument type of class/definition
+  type GetLHSArg[ArgIdx]    = OpMacro[OpId.GetLHSArg, ArgIdx, NP, NP] //Use to get argument type of the left-hand-side
+  final val  GetArg         = impl.GetArg
+  final val  GetLHSArg      = impl.GetLHSArg
   type GetArg0              = GetArg[W.`0`.T]
+  type GetLHSArg0           = GetLHSArg[W.`0`.T]
   type Id[P1]               = OpMacro[OpId.Id, P1, NP, NP]
   type ![P1]                = OpMacro[OpId.!, P1, NP, NP]
   type Require[Cond]        = OpMacro[OpId.Require, Cond, DefaultRequireMsg, NP]

--- a/src/test/scala/singleton/ops/GetArgSpec.scala
+++ b/src/test/scala/singleton/ops/GetArgSpec.scala
@@ -21,7 +21,7 @@ class GetArgSpec extends Properties("GetArgSpec") {
     illTyped("smallerThan50(51)")
   }
   property("Unsupported GetArg") = wellTyped {
-    illTyped("implicitly[GAT0]") //cannot be invoked without implicit conversion
+    illTyped("implicitly[GetArg0]") //cannot be invoked without implicit conversion
     illTyped("smallerThan50(1L)") //Argument index too large in `BadConvLong`
     illTyped("implicitly[GetArg[W.`0.1`.T]]") //Bad argument (Double instead of Int)
   }

--- a/src/test/scala/singleton/ops/GetLHSArgSpec.scala
+++ b/src/test/scala/singleton/ops/GetLHSArgSpec.scala
@@ -10,6 +10,7 @@ class GetLHSArgSpec extends Properties("GetLHSArgSpec") {
   }
 
   implicit class ConvInt(val int : Int) {
+    def ext(implicit g : GetLHSArg0) : g.Out = g.value
     def <= [T, Out](that : Conv[T])(implicit g : OpAuxGen[AcceptNonLiteral[GetLHSArg0], Out]) : Conv[Out] = new Conv[Out](g.value){}
     def := [T, Out](that : Conv[T])(implicit g : GetLHSArg.Aux[W.`0`.T, Out]) : Conv[Out] = new Conv[Out](g){}
   }
@@ -18,6 +19,7 @@ class GetLHSArgSpec extends Properties("GetLHSArgSpec") {
     val c = new Conv(2){}
     val out = 12 <= c
     implicitly[out.Out =:= W.`12`.T]
+    val out2 : W.`12`.T = 12.ext
     out.value == 12
   }
 
@@ -49,5 +51,6 @@ class GetLHSArgSpec extends Properties("GetLHSArgSpec") {
     val out2 : W.`3L`.T  = new Foo(1, "me")(3L)(true) getArg 2
     val out3 : W.`true`.T  = new Foo(1, "me")(3L)(true) getArg 3
   }
+
 
 }

--- a/src/test/scala/singleton/ops/GetLHSArgSpec.scala
+++ b/src/test/scala/singleton/ops/GetLHSArgSpec.scala
@@ -1,0 +1,53 @@
+package singleton.ops
+
+import org.scalacheck.Properties
+import shapeless.test.illTyped
+import singleton.TestUtils._
+
+class GetLHSArgSpec extends Properties("GetLHSArgSpec") {
+  abstract class Conv[T](val value : T) {
+    type Out = T
+  }
+
+  implicit class ConvInt(val int : Int) {
+    def <= [T, Out](that : Conv[T])(implicit g : OpAuxGen[AcceptNonLiteral[GetLHSArg0], Out]) : Conv[Out] = new Conv[Out](g.value){}
+    def := [T, Out](that : Conv[T])(implicit g : GetLHSArg.Aux[W.`0`.T, Out]) : Conv[Out] = new Conv[Out](g){}
+  }
+
+  property("implicit class argument with GetLHSArg0") = {
+    val c = new Conv(2){}
+    val out = 12 <= c
+    implicitly[out.Out =:= W.`12`.T]
+    out.value == 12
+  }
+
+  property("implicit class argument with GetLHSArg.Aux") = {
+    val c = new Conv(2){}
+    val out = 12 := c
+    implicitly[out.Out =:= W.`12`.T]
+    out.value == 12
+  }
+
+  def bad(i : Int)(implicit arg : GetLHSArg0) : Unit ={}
+
+  property("no LHS arguments fails macro") = wellTyped {
+    illTyped("""bad(4)""", "Left-hand-side tree not found")
+  }
+
+  property("Unsupported GetLHSArg") = wellTyped {
+    illTyped("implicitly[GetLHSArg[W.`-1`.T]]") //Bad argument (Negative Int)
+    illTyped("implicitly[GetLHSArg[W.`0.1`.T]]") //Bad argument (Double instead of Int)
+  }
+
+  class Foo(value0 : Any, value1 : Any)(value2 : Any)(value3 : Any){
+    def getArg[I <: XInt](idx : I)(implicit g : GetLHSArg[I]) : g.Out = g.value
+  }
+
+  property("Multiple LHS arguments") = wellTyped {
+    val out0 : W.`1`.T = new Foo(1, "me")(3L)(true) getArg 0
+    val out1 : W.`"me"`.T  = new Foo(1, "me")(3L)(true) getArg 1
+    val out2 : W.`3L`.T  = new Foo(1, "me")(3L)(true) getArg 2
+    val out3 : W.`true`.T  = new Foo(1, "me")(3L)(true) getArg 3
+  }
+
+}

--- a/src/test/scala/singleton/ops/GetLHSArgSpec.scala
+++ b/src/test/scala/singleton/ops/GetLHSArgSpec.scala
@@ -42,14 +42,14 @@ class GetLHSArgSpec extends Properties("GetLHSArgSpec") {
   }
 
   class Foo(value0 : Any, value1 : Any)(value2 : Any)(value3 : Any){
-    def getArg[I <: XInt](idx : I)(implicit g : GetLHSArg[I]) : g.Out = g.value
+    def getArg[I <: Int](idx : I)(implicit g : GetLHSArg[I]) : g.Out = g.value
   }
 
   property("Multiple LHS arguments") = wellTyped {
-    val out0 : W.`1`.T = new Foo(1, "me")(3L)(true) getArg 0
-    val out1 : W.`"me"`.T  = new Foo(1, "me")(3L)(true) getArg 1
-    val out2 : W.`3L`.T  = new Foo(1, "me")(3L)(true) getArg 2
-    val out3 : W.`true`.T  = new Foo(1, "me")(3L)(true) getArg 3
+    val out0 : W.`1`.T = new Foo(1, "me")(3L)(true) getArg W(0).value
+    val out1 : W.`"me"`.T  = new Foo(1, "me")(3L)(true) getArg W(1).value
+    val out2 : W.`3L`.T  = new Foo(1, "me")(3L)(true) getArg W(2).value
+    val out3 : W.`true`.T  = new Foo(1, "me")(3L)(true) getArg W(3).value
   }
 
 


### PR DESCRIPTION
Similar to `GetArg`, `GetLHSArg` allows us to get narrow arguments' type, but this time for the left-hand-side expression. This is mostly usable for implicit classes. Example:

```scala
  abstract class Conv[T](val value : T) {
    type Out = T
  }

  implicit class ConvInt(val int : Int) {
    def <= [T](that : Conv[T])(implicit g : GetLHSArg0) : Conv[g.out] = new Conv[g.out](g.value){}
  }
```
```scala
  val c = new Conv(2){}
  val out = 12 <= c
  implicitly[out.Out =:= 12]
```