### PR TITLE
Add 2.13.0 info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ val myBadVec = MyVec[-1] //fails compilation, as required
 ---
 ## Using singleton-ops
 
-The latest version of the library is 0.4.0, which is available for Typelevel Scala v4 for Scala versions 2.11.12 & 2.12.4.
+The latest version of the library is 0.4.0, which is available for Scala versions 2.11.12, 2.12.8, and 2.13.0.
 
 If you're using sbt, add the following to your build:
 


### PR DESCRIPTION
Fixes #92 
@fthomas why scaladex still listing 0.3.0 as the latest build version?