### PR TITLE
Improvements under 2.13.x and some global conversions removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ project/plugins/project/
 
 # IDEA specific
 .idea*/
+/.bloop/
+/.metals/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.9

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.2.8

--- a/src/main/scala/singleton/ops/OpContainer.scala
+++ b/src/main/scala/singleton/ops/OpContainer.scala
@@ -1,0 +1,19 @@
+package singleton.ops
+
+object OpContainer {
+  //Create an equivalence implicit rule with this `Eq` type
+  //F - from type
+  //T - to type
+  //Wide - the T and F wide representation
+  type Eq[F, T, Wide] = Require[ITE[IsNonLiteral[T], ImplicitFound[T =:= Wide], F == T]]
+
+  //For an op container with a single argument, extend the companion object using this trait.
+  //For example:
+  //class Vec[Size]
+  //object Vec extends OpContainer.Eq1[Vec, Int]
+  //val v1 : Vec[2] = new Vec[1 + 1]
+  //val vInt : Vec[Int] = new Vec[1 + 1]
+  trait Eq1[C[F1], Wide1] {
+    implicit def argCast[F1,T1](c : C[F1])(implicit eq : Eq[F1,T1,Wide1]) : C[T1] = c.asInstanceOf[C[T1]]
+  }
+}

--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -737,7 +737,7 @@ trait GeneralMacros {
       case t : CalcLit => t
       case t : CalcType => CalcNLit(t, q"$tfTree.getValue")
       case t =>
-        println(t)
+//        println(t)
         extractionFailed(typedTree.tpe)
     }
   }
@@ -793,12 +793,12 @@ trait GeneralMacros {
 
     def apply(argIdx : Int, lhs : Boolean) : c.Tree = {
       val tree = c.enclosingImplicits.last.tree
-      println(">>>>>>> enclosingImpl: " + c.enclosingImplicits.last)
-      println("tree: " + c.enclosingImplicits.last.tree)
-      println("rawTree: " + showRaw(c.enclosingImplicits.last.tree))
+//      println(">>>>>>> enclosingImpl: " + c.enclosingImplicits.last)
+//      println("tree: " + c.enclosingImplicits.last.tree)
+//      println("rawTree: " + showRaw(c.enclosingImplicits.last.tree))
       val allArgs = if (lhs) getAllLHSArgs(tree) else getAllArgs(tree, lhs)
-      println("args: " + allArgs)
-      println("<<<<<<< rawArgs" + showRaw(allArgs))
+//      println("args: " + allArgs)
+//      println("<<<<<<< rawArgs" + showRaw(allArgs))
       if (argIdx < allArgs.length) allArgs(argIdx)
       else abort(s"Argument index($argIdx) is not smaller than the total number of arguments(${allArgs.length})")
     }

--- a/src/main/scala/singleton/ops/package.scala
+++ b/src/main/scala/singleton/ops/package.scala
@@ -196,49 +196,4 @@ package object ops {
     check : Require[OP_OUTA == OP_OUTB]
   ) : OpMacro[NB, SB1, SB2, SB3] = opB
   /////////////////////////////////////////////////
-
-
-  /////////////////////////////////////////////////
-  //Implicit proof for type class containers of
-  //singleton type operations & literals
-  /////////////////////////////////////////////////
-  implicit def opContainer1[
-  F,
-  T,
-  C[_]
-  ](cf : C[F])
-   (implicit
-    ct : C[T],
-    check : Require[
-      F == T
-      ])
-  : C[T] = ct
-
-  implicit def opContainer2[
-  F1, F2,
-  T1, T2,
-  C[_,_]
-  ](cf : C[F1, F2])
-   (implicit
-    ct : C[T1, T2],
-    check : Require[
-        (F1 == T1) &&
-        (F2 == T2)
-      ]
-   ) : C[T1, T2] = ct
-
-  implicit def opContainer3[
-  F1, F2, F3,
-  T1, T2, T3,
-  C[_,_,_]
-  ](cf : C[F1, F2, F3])
-   (implicit
-    ct : C[T1, T2, T3],
-    check : Require[
-        (F1 == T1) &&
-        (F2 == T2) &&
-        (F3 == T3)
-      ]
-   ) : C[T1, T2, T3] = ct
-  /////////////////////////////////////////////////
 }

--- a/src/main/scala_2.13+/singleton/twoface/impl/Checked0ParamAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/Checked0ParamAny.scala
@@ -52,8 +52,9 @@ object Checked0ParamAny {
       implicit req : RequireMsg[IsNonLiteral[T] || Cond[T], Msg[T]], di : DummyImplicit
     ) : Chk[Cond, Msg, T] = create[Cond, Msg, T](tfValue.getValue)
 
-    implicit def widen[Cond[_], Msg[_], T](value : Chk[Cond, Msg, T])(implicit di : DummyImplicit)
-    : Chk[Cond, Msg, Face] = value.asInstanceOf[Chk[Cond, Msg, Face]]
+    implicit def argCast[Cond[_], Msg[_], F, T](c : Chk[Cond, Msg, F])(
+      implicit eq : OpContainer.Eq[F, T, Face]
+    ) : Chk[Cond, Msg, T] = c.asInstanceOf[Chk[Cond, Msg, T]]
     ////////////////////////////////////////////////////////////////////////////////////////
   }
 

--- a/src/main/scala_2.13+/singleton/twoface/impl/Checked0ParamAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/Checked0ParamAny.scala
@@ -14,9 +14,19 @@ trait Checked0ParamAny[Chk[Cond0[_], Msg0[_], T0], Cond[_], Msg[_], Face, T] ext
 
 object Checked0ParamAny {
   trait LP[Chk[Cond0[_], Msg0[_], T0], Face] {
-    implicit def fromNum[Cond[_], Msg[_], T >: Face, Out <: T](value : T)
+    def create[Cond[_], Msg[_], T](value : Face) : Chk[Cond, Msg, T]
+
+    //This is a hack to force Scalac to actually display the constructed error message in all cases
+    //From some weird reason only direct macro calls displays the error in a case of an implicit conversion
+    implicit def requireMsg[Cond[_], Msg[_], T >: Face, Out <: T](value : T)
     : Chk[Cond, Msg, Out] = macro Builder.Macro.fromNumValue[Chk[Cond,Msg,_], Cond[_], Msg[_], T]
+
+    //from non-singleton values
+    implicit def fromNumNonSing[Cond[_], Msg[_]](value : Face)(
+      implicit req : ITE[IsNonLiteral[GetArg0], true, RequireMsg[Cond[GetArg0], Msg[GetArg0]]], di : DummyImplicit
+    ) : Chk[Cond, Msg, Face] = create[Cond, Msg, Face](value)
   }
+
   trait Builder[Chk[Cond0[_], Msg0[_], T0], Face] extends LP[Chk, Face] {
     trait Alias {
       type Cond[T]
@@ -25,48 +35,34 @@ object Checked0ParamAny {
       final type CheckedShell[T] = CheckedShellSym[NoSym, T]
       final type CheckedShellSym[Sym, T] = CheckedShell1[Cond, Msg, Sym, T, Face]
     }
-    def create[Cond[_], Msg[_], T](value : Face) : Chk[Cond, Msg, T]
 
     ////////////////////////////////////////////////////////////////////////////////////////
     // Generic Implicit Conversions
     // Currently triggers good-code-red IntelliJ issue
     // https://youtrack.jetbrains.com/issue/SCL-13089
     ////////////////////////////////////////////////////////////////////////////////////////
-    implicit def ev[Cond[_], Msg[_], T](implicit value : AcceptNonLiteral[Id[T]])
-    : Chk[Cond, Msg, T] = macro Builder.Macro.fromOpImpl[Chk[Cond,Msg,_], Cond[_], Msg[_], T]
+    implicit def ev[Cond[_], Msg[_], T](implicit req : RequireMsg[Cond[T], Msg[T]], value : AcceptNonLiteral[Id[T]])
+    : Chk[Cond, Msg, T] = create[Cond, Msg, T](value.valueWide.asInstanceOf[Face])
 
-    implicit def fromNumSing[Cond[_], Msg[_], T <: Face with Singleton](value : T)(implicit req : RequireMsg[Cond[T], Msg[T]])
-    : Chk[Cond, Msg, T] = create[Cond, Msg, T](value)
+    implicit def fromNumSing[Cond[_], Msg[_], T <: Face with Singleton](value : T)(
+      implicit req : RequireMsg[Cond[T], Msg[T]]
+    ) : Chk[Cond, Msg, T] = create[Cond, Msg, T](value)
 
-    implicit def fromTF[Cond[_], Msg[_], T >: Face, Out <: T](value : TwoFaceAny[Face, T])
-    : Chk[Cond, Msg, Out] = macro Builder.Macro.fromTF[Chk[Cond,Msg,_], Cond[_], Msg[_], T]
+    implicit def fromTF[Cond[_], Msg[_], T](tfValue : TwoFaceAny[Face, T])(
+      implicit req : RequireMsg[IsNonLiteral[T] || Cond[T], Msg[T]], di : DummyImplicit
+    ) : Chk[Cond, Msg, T] = create[Cond, Msg, T](tfValue.getValue)
 
-    implicit def widen[Cond[_], Msg[_], T](value : Chk[Cond, Msg, T])
+    implicit def widen[Cond[_], Msg[_], T](value : Chk[Cond, Msg, T])(implicit di : DummyImplicit)
     : Chk[Cond, Msg, Face] = value.asInstanceOf[Chk[Cond, Msg, Face]]
     ////////////////////////////////////////////////////////////////////////////////////////
   }
 
   object Builder {
     final class Macro(val c: whitebox.Context) extends GeneralMacros {
-      def fromOpImpl[Chk, Cond, Msg, T](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
-      ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].fromOpImpl(value)
-
       def fromNumValue[Chk, Cond, Msg, T](value : c.Tree)(
         implicit
         chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
       ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].fromNumValue(value)
-
-      def fromTF[Chk, Cond, Msg, T](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
-      ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].fromTF(value)
-
-      def widen[Chk, Cond, Msg, T](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T]
-      ): c.Tree = Checked0ParamMaterializer[Chk, Cond, Msg, T].widen(value)
     }
   }
 
@@ -78,6 +74,7 @@ object Checked0ParamAny {
     def create[Cond[_], Msg[_], T](value: std.Char): Char[Cond, Msg, T] = new Char[Cond, Msg, T](value)
   }
 
+  @scala.annotation.implicitNotFound("haha")
   final class Int[Cond[_], Msg[_], T](val value : std.Int) extends
     Checked0ParamAny[Int, Cond, Msg, std.Int, T] with TwoFaceAny.Int[T] {
     @inline def getValue : std.Int = value

--- a/src/main/scala_2.13+/singleton/twoface/impl/Checked1ParamAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/Checked1ParamAny.scala
@@ -15,8 +15,17 @@ trait Checked1ParamAny[Chk[Cond0[_,_], Msg0[_,_], T0, ParamFace0, Param0], Cond[
 
 object Checked1ParamAny {
   trait LP[Chk[Cond0[_,_], Msg0[_,_], T0, ParamFace0, Param0], Face] {
-    implicit def fromNum[Cond[_,_], Msg[_,_], T >: Face, ParamFace, Param, Out <: T](value : T)
-    : Chk[Cond, Msg, Out, ParamFace, Param] = macro Builder.Macro.fromNumValue[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param]
+    def create[Cond[_,_], Msg[_,_], T, ParamFace, Param](value : Face) : Chk[Cond, Msg, T, ParamFace, Param]
+
+    //This is a hack to force Scalac to actually display the constructed error message in all cases
+    //From some weird reason only direct macro calls displays the error in a case of an implicit conversion
+    implicit def requireMsg[Cond[_,_], Msg[_,_], T >: Face, ParamFace, Param, Out <: T](value : T)
+    : Chk[Cond, Msg, Out, ParamFace, Param] = macro Builder.Macro.requireMsg[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param]
+
+    //from non-singleton values
+    implicit def fromNumNonSing[Cond[_,_], Msg[_,_], ParamFace, Param](value : Face)(
+      implicit req : RequireMsg[IsNonLiteral[GetArg0] || IsNonLiteral[Param] || Cond[GetArg0, Param], Msg[GetArg0, Param]],
+    ) : Chk[Cond, Msg, Face, ParamFace, Param] = create[Cond, Msg, Face, ParamFace, Param](value)
   }
   trait Builder[Chk[Cond0[_,_], Msg0[_,_], T0, ParamFace0, Param0], Face] extends LP[Chk, Face]{
     trait Alias {
@@ -27,22 +36,23 @@ object Checked1ParamAny {
       final type CheckedShell[T, Param] = CheckedShellSym[NoSym, T, Param]
       final type CheckedShellSym[Sym, T, Param] = CheckedShell2[Cond, Msg, Sym, T, Face, Param, ParamFace]
     }
-    
-    def create[Cond[_,_], Msg[_,_], T, ParamFace, Param](value : Face) : Chk[Cond, Msg, T, ParamFace, Param]
 
     ////////////////////////////////////////////////////////////////////////////////////////
     // Generic Implicit Conversions
     // Currently triggers good-code-red IntelliJ issue
     // https://youtrack.jetbrains.com/issue/SCL-13089
     ////////////////////////////////////////////////////////////////////////////////////////
-    implicit def ev[Cond[_,_], Msg[_,_], ParamFace, T, Param](implicit value : AcceptNonLiteral[Id[T]])
-    : Chk[Cond, Msg, T, ParamFace, Param] = macro Builder.Macro.fromOpImpl[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param]
+    implicit def ev[Cond[_,_], Msg[_,_], ParamFace, T, Param](
+      implicit req : RequireMsg[IsNonLiteral[Param] || Cond[T, Param], Msg[T, Param]], value : AcceptNonLiteral[Id[T]]
+    ) : Chk[Cond, Msg, T, ParamFace, Param] = create[Cond, Msg, T, ParamFace, Param](value.valueWide.asInstanceOf[Face])
 
-    implicit def fromNumSing[Cond[_,_], Msg[_,_], T <: Face with Singleton, ParamFace, Param](value : T)(implicit req : RequireMsg[Cond[T, Param], Msg[T, Param]])
-    : Chk[Cond, Msg, T, ParamFace, Param] = create[Cond, Msg, T, ParamFace, Param](value)
+    implicit def fromNumSing[Cond[_,_], Msg[_,_], T <: Face with Singleton, ParamFace, Param](value : T)(
+      implicit req : RequireMsg[IsNonLiteral[Param] || Cond[T, Param], Msg[T, Param]]
+    ) : Chk[Cond, Msg, T, ParamFace, Param] = create[Cond, Msg, T, ParamFace, Param](value)
 
-    implicit def fromTF[Cond[_,_], Msg[_,_], T >: Face, ParamFace, Param, Out <: T](value : TwoFaceAny[Face, T])
-    : Chk[Cond, Msg, Out, ParamFace, Param] = macro Builder.Macro.fromTF[Chk[Cond,Msg,_,_,_], Cond[_,_], Msg[_,_], T, ParamFace, Param]
+    implicit def fromTF[Cond[_,_], Msg[_,_], T, ParamFace, Param](tfValue : TwoFaceAny[Face, T])(
+      implicit req : RequireMsg[IsNonLiteral[T] || IsNonLiteral[Param] || Cond[T, Param], Msg[T, Param]], di : DummyImplicit
+    ) : Chk[Cond, Msg, T, ParamFace, Param] = create[Cond, Msg, T, ParamFace, Param](tfValue.getValue)
 
     implicit def widen[Cond[_,_], Msg[_,_], T, ParamFace, Param](value : Chk[Cond, Msg, T, ParamFace, Param])
     : Chk[Cond, Msg, Face, ParamFace, Param] = value.asInstanceOf[Chk[Cond, Msg, Face, ParamFace, Param]]
@@ -51,25 +61,10 @@ object Checked1ParamAny {
 
   object Builder {
     final class Macro(val c: whitebox.Context) extends GeneralMacros {
-      def fromOpImpl[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
-      ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].fromOpImpl(value)
-
-      def fromNumValue[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(
+      def requireMsg[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(
         implicit
         chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
       ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].fromNumValue(value)
-
-      def fromTF[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
-      ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].fromTF(value)
-
-      def widen[Chk, Cond, Msg, T, ParamFace, Param](value : c.Tree)(
-        implicit
-        chk : c.WeakTypeTag[Chk], cond : c.WeakTypeTag[Cond], msg : c.WeakTypeTag[Msg], t : c.WeakTypeTag[T], paramFace : c.WeakTypeTag[ParamFace], p : c.WeakTypeTag[Param]
-      ): c.Tree = Checked1ParamMaterializer[Chk, Cond, Msg, T, ParamFace, Param].widen(value)
     }
   }
 

--- a/src/main/scala_2.13+/singleton/twoface/impl/Checked1ParamAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/Checked1ParamAny.scala
@@ -54,8 +54,9 @@ object Checked1ParamAny {
       implicit req : RequireMsg[IsNonLiteral[T] || IsNonLiteral[Param] || Cond[T, Param], Msg[T, Param]], di : DummyImplicit
     ) : Chk[Cond, Msg, T, ParamFace, Param] = create[Cond, Msg, T, ParamFace, Param](tfValue.getValue)
 
-    implicit def widen[Cond[_,_], Msg[_,_], T, ParamFace, Param](value : Chk[Cond, Msg, T, ParamFace, Param])
-    : Chk[Cond, Msg, Face, ParamFace, Param] = value.asInstanceOf[Chk[Cond, Msg, Face, ParamFace, Param]]
+    implicit def argCast[Cond[_,_], Msg[_,_], F, T, ParamFace, Param](c : Chk[Cond, Msg, F, ParamFace, Param])(
+      implicit eq : OpContainer.Eq[F, T, Face]
+    ) : Chk[Cond, Msg, T, ParamFace, Param] = c.asInstanceOf[Chk[Cond, Msg, T, ParamFace, Param]]
     ////////////////////////////////////////////////////////////////////////////////////////
   }
 

--- a/src/main/scala_2.13+/singleton/twoface/impl/TwoFaceAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/TwoFaceAny.scala
@@ -1,9 +1,7 @@
 package singleton.twoface.impl
 
 import singleton.ops._
-import singleton.ops.impl.{GeneralMacros, std}
-
-import scala.reflect.macros.whitebox
+import singleton.ops.impl.std
 
 trait TwoFaceAny[Face, T] extends Any {
   type Out = T
@@ -81,18 +79,6 @@ object TwoFaceAny {
     //However, since IntelliJ marks everything red, it was preferred to implement it specifically, in the meantime.
     //implicit def apply[T <: Face](value : T) : Lt[T] = macro Builder.Macro.fromNumValue
 
-  }
-
-
-  object Builder {
-    final class Macro(val c: whitebox.Context) extends GeneralMacros {
-      def fromNumValue[TF](value : c.Tree)(implicit tfTag : c.WeakTypeTag[TF]) : c.Tree =
-        TwoFaceMaterializer.fromNumValue(value, c.symbolOf[TF])
-      def toNumValue[TF, T](tf : c.Tree)(implicit tTag : c.WeakTypeTag[T], tfTag : c.WeakTypeTag[TF]) : c.Tree =
-        TwoFaceMaterializer.toNumValue(tf, c.symbolOf[TF], c.weakTypeOf[T])
-      def toNumValue2[TF, T](tf : c.Tree)(id : c.Tree)(implicit tTag : c.WeakTypeTag[T], tfTag : c.WeakTypeTag[TF]) : c.Tree =
-        TwoFaceMaterializer.toNumValue(tf, c.symbolOf[TF], c.weakTypeOf[T])
-    }
   }
 
   trait Char[T] extends Any with TwoFaceAny[std.Char, T] {

--- a/src/main/scala_2.13+/singleton/twoface/impl/TwoFaceAny.scala
+++ b/src/main/scala_2.13+/singleton/twoface/impl/TwoFaceAny.scala
@@ -165,13 +165,12 @@ object TwoFaceAny {
   final class _Char[T](val value : std.Char) extends AnyVal with Char[T] {
     @inline def getValue : std.Char = value
   }
-  implicit object Char extends TwoFaceAny.Builder[Char, std.Char, Shell.One.Char, Shell.Two.Char, Shell.Three.Char] {
+  implicit object Char extends TwoFaceAny.Builder[Char, std.Char, Shell.One.Char, Shell.Two.Char, Shell.Three.Char] with OpContainer.Eq1[Char, std.Char] {
     def create[T](value : std.Char) : Char[T] = new _Char[T](value)
     def apply[T <: std.Char with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Char[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Char with Singleton](value : T) : Char[T] = create[T](value)
     implicit def apply[T <: std.Char](value : T)(implicit di : DummyImplicit) : Char[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Char[T] = create[T](id.valueWide.asInstanceOf[std.Char])
-    implicit def widen[T](tf : Char[T]) : Char[std.Char] = tf.asInstanceOf[Char[std.Char]]
     implicit def tf2NumSingleton[T <: std.Char with Singleton](tf : Char[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Char[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutChar = id.value.asInstanceOf[id.OutChar]
     implicit def tf2NumWide[T](tf : Char[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Char = tf.getValue
@@ -261,14 +260,13 @@ object TwoFaceAny {
   final class _Int[T](val value : std.Int) extends AnyVal with Int[T] {
     @inline def getValue : std.Int = value
   }
-  implicit object Int extends TwoFaceAny.Builder[Int, std.Int, Shell.One.Int, Shell.Two.Int, Shell.Three.Int] {
+  implicit object Int extends TwoFaceAny.Builder[Int, std.Int, Shell.One.Int, Shell.Two.Int, Shell.Three.Int] with OpContainer.Eq1[Int, std.Int] {
     def numberOfLeadingZeros[T](t : Int[T])(implicit tfs : Int.Shell1[NumberOfLeadingZeros, T, std.Int]) = tfs(t.getValue)
     def create[T](value : std.Int) : Int[T] = new _Int[T](value)
     def apply[T <: std.Int with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Int[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Int with Singleton](value : T) : Int[T] = create[T](value)
     implicit def apply[T <: std.Int](value : T)(implicit di : DummyImplicit) : Int[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Int[T] = create[T](id.valueWide.asInstanceOf[std.Int])
-    implicit def widen[T](tf : Int[T]) : Int[std.Int] = tf.asInstanceOf[Int[std.Int]]
     implicit def tf2NumSingleton[T <: std.Int with Singleton](tf : Int[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Int[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutInt = id.value.asInstanceOf[id.OutInt]
     implicit def tf2NumWide[T](tf : Int[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Int = tf.getValue
@@ -359,14 +357,13 @@ object TwoFaceAny {
   final class _Long[T](val value : std.Long) extends AnyVal with Long[T] {
     @inline def getValue : std.Long = value
   }
-  implicit object Long extends TwoFaceAny.Builder[Long, std.Long, Shell.One.Long, Shell.Two.Long, Shell.Three.Long] {
+  implicit object Long extends TwoFaceAny.Builder[Long, std.Long, Shell.One.Long, Shell.Two.Long, Shell.Three.Long] with OpContainer.Eq1[Long, std.Long] {
     def numberOfLeadingZeros[T](t : Long[T])(implicit tfs : Int.Shell1[NumberOfLeadingZeros, T, std.Long]) = tfs(t.getValue)
     def create[T](value : std.Long) : Long[T] = new _Long[T](value)
     def apply[T <: std.Long with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Long[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Long with Singleton](value : T) : Long[T] = create[T](value)
     implicit def apply[T <: std.Long](value : T)(implicit di : DummyImplicit) : Long[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Long[T] = create[T](id.valueWide.asInstanceOf[std.Long])
-    implicit def widen[T](tf : Long[T]) : Long[std.Long] = tf.asInstanceOf[Long[std.Long]]
     implicit def tf2NumSingleton[T <: std.Long with Singleton](tf : Long[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Long[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutLong = id.value.asInstanceOf[id.OutLong]
     implicit def tf2NumWide[T](tf : Long[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Long = tf.getValue
@@ -456,13 +453,12 @@ object TwoFaceAny {
   final class _Float[T](val value : std.Float) extends AnyVal with Float[T] {
     @inline def getValue : std.Float = value
   }
-  implicit object Float extends TwoFaceAny.Builder[Float, std.Float, Shell.One.Float, Shell.Two.Float, Shell.Three.Float] {
+  implicit object Float extends TwoFaceAny.Builder[Float, std.Float, Shell.One.Float, Shell.Two.Float, Shell.Three.Float] with OpContainer.Eq1[Float, std.Float] {
     def create[T](value : std.Float) : Float[T] = new _Float[T](value)
     def apply[T <: std.Float with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Float[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Float with Singleton](value : T) : Float[T] = create[T](value)
     implicit def apply[T <: std.Float](value : T)(implicit di : DummyImplicit) : Float[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Float[T] = create[T](id.valueWide.asInstanceOf[std.Float])
-    implicit def widen[T](tf : Float[T]) : Float[std.Float] = tf.asInstanceOf[Float[std.Float]]
     implicit def tf2NumSingleton[T <: std.Float with Singleton](tf : Float[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Float[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutFloat = id.value.asInstanceOf[id.OutFloat]
     implicit def tf2NumWide[T](tf : Float[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Float = tf.getValue
@@ -552,13 +548,12 @@ object TwoFaceAny {
   final class _Double[T](val value : std.Double) extends AnyVal with Double[T] {
     @inline def getValue : std.Double = value
   }
-  implicit object Double extends TwoFaceAny.Builder[Double, std.Double, Shell.One.Double, Shell.Two.Double, Shell.Three.Double] {
+  implicit object Double extends TwoFaceAny.Builder[Double, std.Double, Shell.One.Double, Shell.Two.Double, Shell.Three.Double] with OpContainer.Eq1[Double, std.Double] {
     def create[T](value : std.Double) : Double[T] = new _Double[T](value)
     def apply[T <: std.Double with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Double[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Double with Singleton](value : T) : Double[T] = create[T](value)
     implicit def apply[T <: std.Double](value : T)(implicit di : DummyImplicit) : Double[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Double[T] = create[T](id.valueWide.asInstanceOf[std.Double])
-    implicit def widen[T](tf : Double[T]) : Double[std.Double] = tf.asInstanceOf[Double[std.Double]]
     implicit def tf2NumSingleton[T <: std.Double with Singleton](tf : Double[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Double[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutDouble = id.value.asInstanceOf[id.OutDouble]
     implicit def tf2NumWide[T](tf : Double[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Double = tf.getValue
@@ -589,13 +584,12 @@ object TwoFaceAny {
   final class _String[T](val value : std.String) extends AnyVal with String[T] {
     @inline def getValue : std.String = value
   }
-  implicit object String extends TwoFaceAny.Builder[String, std.String, Shell.One.String, Shell.Two.String, Shell.Three.String] {
+  implicit object String extends TwoFaceAny.Builder[String, std.String, Shell.One.String, Shell.Two.String, Shell.Three.String] with OpContainer.Eq1[String, std.String] {
     def create[T](value : std.String) : String[T] = new _String[T](value)
     def apply[T <: std.String with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : String[T] = create[T](valueOf[T])
     implicit def apply[T <: std.String with Singleton](value : T) : String[T] = create[T](value)
     implicit def apply[T <: std.String](value : T)(implicit di : DummyImplicit) : String[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : String[T] = create[T](id.valueWide.asInstanceOf[std.String])
-    implicit def widen[T](tf : String[T]) : String[std.String] = tf.asInstanceOf[String[std.String]]
     implicit def tf2NumSingleton[T <: std.String with Singleton](tf : String[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : String[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutString = id.value.asInstanceOf[id.OutString]
     implicit def tf2NumWide[T](tf : String[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.String = tf.getValue
@@ -619,13 +613,12 @@ object TwoFaceAny {
   final class _Boolean[T](val value : std.Boolean) extends AnyVal with Boolean[T] {
     @inline def getValue : std.Boolean = value
   }
-  implicit object Boolean extends TwoFaceAny.Builder[Boolean, std.Boolean, Shell.One.Boolean, Shell.Two.Boolean, Shell.Three.Boolean] {
+  implicit object Boolean extends TwoFaceAny.Builder[Boolean, std.Boolean, Shell.One.Boolean, Shell.Two.Boolean, Shell.Three.Boolean] with OpContainer.Eq1[Boolean, std.Boolean] {
     def create[T](value : std.Boolean) : Boolean[T] = new _Boolean[T](value)
     def apply[T <: std.Boolean with Singleton](implicit value : ValueOf[T], di : DummyImplicit, di2 : DummyImplicit) : Boolean[T] = create[T](valueOf[T])
     implicit def apply[T <: std.Boolean with Singleton](value : T) : Boolean[T] = create[T](value)
     implicit def apply[T <: std.Boolean](value : T)(implicit di : DummyImplicit) : Boolean[T] = create[T](value)
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Boolean[T] = create[T](id.valueWide.asInstanceOf[std.Boolean])
-    implicit def widen[T](tf : Boolean[T]) : Boolean[std.Boolean] = tf.asInstanceOf[Boolean[std.Boolean]]
     implicit def tf2NumSingleton[T <: std.Boolean with Singleton](tf : Boolean[T])(implicit value : ValueOf[T]) : T = valueOf[T]
     implicit def tf2NumOp[T](tf : Boolean[T])(implicit id : AcceptNonLiteral[Id[T]]) : id.OutBoolean = id.value.asInstanceOf[id.OutBoolean]
     implicit def tf2NumWide[T](tf : Boolean[T])(implicit di : DummyImplicit, di2 : DummyImplicit) : std.Boolean = tf.getValue

--- a/src/main/scala_2.13-/singleton/twoface/impl/TwoFaceAny.scala
+++ b/src/main/scala_2.13-/singleton/twoface/impl/TwoFaceAny.scala
@@ -179,12 +179,11 @@ object TwoFaceAny {
   final class _Char[T](val value : std.Char) extends AnyVal with Char[T] {
     @inline def getValue : std.Char = value
   }
-  implicit object Char extends TwoFaceAny.Builder[Char, std.Char, Shell.One.Char, Shell.Two.Char, Shell.Three.Char] {
+  implicit object Char extends TwoFaceAny.Builder[Char, std.Char, Shell.One.Char, Shell.Two.Char, Shell.Three.Char] with OpContainer.Eq1[Char, std.Char] {
     def create[T](value : std.Char) : Char[T] = new _Char[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Char[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Char])
     implicit def apply[T <: std.Char, Out <: T](value : T) : Char[Out] = macro Builder.Macro.fromNumValue[Char[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Char[T] = create[T](id.valueWide.asInstanceOf[std.Char])
-    implicit def widen[T](tf : Char[T]) : Char[std.Char] = create[std.Char](tf.getValue)
     implicit def tf2Num[T <: std.Char](tf : Char[T]) : T = macro Builder.Macro.toNumValue[Char[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Char](tf : Char[T])(implicit id : OpAuxChar[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Char[_], Out]
     implicit def unsafeTF2Num(tf : Char[_]) : std.Char = macro Builder.Macro.toNumValue[Char[_], std.Char]
@@ -275,13 +274,12 @@ object TwoFaceAny {
   final class _Int[T](val value : std.Int) extends AnyVal with Int[T] {
     @inline def getValue : std.Int = value
   }
-  implicit object Int extends TwoFaceAny.Builder[Int, std.Int, Shell.One.Int, Shell.Two.Int, Shell.Three.Int] {
+  implicit object Int extends TwoFaceAny.Builder[Int, std.Int, Shell.One.Int, Shell.Two.Int, Shell.Three.Int] with OpContainer.Eq1[Int, std.Int] {
     def numberOfLeadingZeros[T](t : Int[T])(implicit tfs : Int.Shell1[NumberOfLeadingZeros, T, std.Int]) = tfs(t.getValue)
     def create[T](value : std.Int) : Int[T] = new _Int[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Int[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Int])
     implicit def apply[T <: std.Int, Out <: T](value : T) : Int[Out] = macro Builder.Macro.fromNumValue[Int[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Int[T] = create[T](id.valueWide.asInstanceOf[std.Int])
-    implicit def widen[T](tf : Int[T]) : Int[std.Int] = create[std.Int](tf.getValue)
     implicit def tf2Num[T <: std.Int](tf : Int[T]) : T = macro Builder.Macro.toNumValue[Int[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Int](tf : Int[T])(implicit id : OpAuxInt[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Int[_], Out]
     implicit def unsafeTF2Num(tf : Int[_]) : std.Int = macro Builder.Macro.toNumValue[Int[_], std.Int]
@@ -373,13 +371,12 @@ object TwoFaceAny {
   final class _Long[T](val value : std.Long) extends AnyVal with Long[T] {
     @inline def getValue : std.Long = value
   }
-  implicit object Long extends TwoFaceAny.Builder[Long, std.Long, Shell.One.Long, Shell.Two.Long, Shell.Three.Long] {
+  implicit object Long extends TwoFaceAny.Builder[Long, std.Long, Shell.One.Long, Shell.Two.Long, Shell.Three.Long] with OpContainer.Eq1[Long, std.Long] {
     def numberOfLeadingZeros[T](t : Long[T])(implicit tfs : Int.Shell1[NumberOfLeadingZeros, T, std.Long]) = tfs(t.getValue)
     def create[T](value : std.Long) : Long[T] = new _Long[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Long[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Long])
     implicit def apply[T <: std.Long, Out <: T](value : T) : Long[Out] = macro Builder.Macro.fromNumValue[Long[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Long[T] = create[T](id.valueWide.asInstanceOf[std.Long])
-    implicit def widen[T](tf : Long[T]) : Long[std.Long] = create[std.Long](tf.getValue)
     implicit def tf2Num[T <: std.Long](tf : Long[T]) : T = macro Builder.Macro.toNumValue[Long[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Long](tf : Long[T])(implicit id : OpAuxLong[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Long[_], Out]
     implicit def unsafeTF2Num(tf : Long[_]) : std.Long = macro Builder.Macro.toNumValue[Long[_], std.Long]
@@ -470,12 +467,11 @@ object TwoFaceAny {
   final class _Float[T](val value : std.Float) extends AnyVal with Float[T] {
     @inline def getValue : std.Float = value
   }
-  implicit object Float extends TwoFaceAny.Builder[Float, std.Float, Shell.One.Float, Shell.Two.Float, Shell.Three.Float] {
+  implicit object Float extends TwoFaceAny.Builder[Float, std.Float, Shell.One.Float, Shell.Two.Float, Shell.Three.Float] with OpContainer.Eq1[Float, std.Float] {
     def create[T](value : std.Float) : Float[T] = new _Float[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Float[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Float])
     implicit def apply[T <: std.Float, Out <: T](value : T) : Float[Out] = macro Builder.Macro.fromNumValue[Float[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Float[T] = create[T](id.valueWide.asInstanceOf[std.Float])
-    implicit def widen[T](tf : Float[T]) : Float[std.Float] = create[std.Float](tf.getValue)
     implicit def tf2Num[T <: std.Float](tf : Float[T]) : T = macro Builder.Macro.toNumValue[Float[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Float](tf : Float[T])(implicit id : OpAuxFloat[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Float[_], Out]
     implicit def unsafeTF2Num(tf : Float[_]) : std.Float = macro Builder.Macro.toNumValue[Float[_], std.Float]
@@ -566,12 +562,11 @@ object TwoFaceAny {
   final class _Double[T](val value : std.Double) extends AnyVal with Double[T] {
     @inline def getValue : std.Double = value
   }
-  implicit object Double extends TwoFaceAny.Builder[Double, std.Double, Shell.One.Double, Shell.Two.Double, Shell.Three.Double] {
+  implicit object Double extends TwoFaceAny.Builder[Double, std.Double, Shell.One.Double, Shell.Two.Double, Shell.Three.Double] with OpContainer.Eq1[Double, std.Double] {
     def create[T](value : std.Double) : Double[T] = new _Double[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Double[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Double])
     implicit def apply[T <: std.Double, Out <: T](value : T) : Double[Out] = macro Builder.Macro.fromNumValue[Double[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Double[T] = create[T](id.valueWide.asInstanceOf[std.Double])
-    implicit def widen[T](tf : Double[T]) : Double[std.Double] = create[std.Double](tf.getValue)
     implicit def tf2Num[T <: std.Double](tf : Double[T]) : T = macro Builder.Macro.toNumValue[Double[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Double](tf : Double[T])(implicit id : OpAuxDouble[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Double[_], Out]
     implicit def unsafeTF2Num(tf : Double[_]) : std.Double = macro Builder.Macro.toNumValue[Double[_], std.Double]
@@ -603,12 +598,11 @@ object TwoFaceAny {
   final class _String[T](val value : std.String) extends AnyVal with String[T] {
     @inline def getValue : std.String = value
   }
-  implicit object String extends TwoFaceAny.Builder[String, std.String, Shell.One.String, Shell.Two.String, Shell.Three.String] {
+  implicit object String extends TwoFaceAny.Builder[String, std.String, Shell.One.String, Shell.Two.String, Shell.Three.String] with OpContainer.Eq1[String, std.String] {
     def create[T](value : std.String) : String[T] = new _String[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : String[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.String])
     implicit def apply[T <: std.String, Out <: T](value : T) : String[Out] = macro Builder.Macro.fromNumValue[String[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : String[T] = create[T](id.valueWide.asInstanceOf[std.String])
-    implicit def widen[T](tf : String[T]) : String[std.String] = create[std.String](tf.getValue)
     implicit def tf2Num[T <: std.String](tf : String[T]) : T = macro Builder.Macro.toNumValue[String[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.String](tf : String[T])(implicit id : OpAuxString[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[String[_], Out]
     implicit def unsafeTF2Num(tf : String[_]) : std.String = macro Builder.Macro.toNumValue[String[_], std.String]
@@ -633,12 +627,11 @@ object TwoFaceAny {
   final class _Boolean[T](val value : std.Boolean) extends AnyVal with Boolean[T] {
     @inline def getValue : std.Boolean = value
   }
-  implicit object Boolean extends TwoFaceAny.Builder[Boolean, std.Boolean, Shell.One.Boolean, Shell.Two.Boolean, Shell.Three.Boolean] {
+  implicit object Boolean extends TwoFaceAny.Builder[Boolean, std.Boolean, Shell.One.Boolean, Shell.Two.Boolean, Shell.Three.Boolean] with OpContainer.Eq1[Boolean, std.Boolean] {
     def create[T](value : std.Boolean) : Boolean[T] = new _Boolean[T](value)
     def apply[T](implicit id : AcceptNonLiteral[Id[T]]) : Boolean[id.Out] = create[id.Out](id.valueWide.asInstanceOf[std.Boolean])
     implicit def apply[T <: std.Boolean, Out <: T](value : T) : Boolean[Out] = macro Builder.Macro.fromNumValue[Boolean[_]]
     implicit def ev[T](implicit id : AcceptNonLiteral[Id[T]]) : Boolean[T] = create[T](id.valueWide.asInstanceOf[std.Boolean])
-    implicit def widen[T](tf : Boolean[T]) : Boolean[std.Boolean] = create[std.Boolean](tf.getValue)
     implicit def tf2Num[T <: std.Boolean](tf : Boolean[T]) : T = macro Builder.Macro.toNumValue[Boolean[_], T]
     implicit def opTF2Num[T <: singleton.ops.impl.Op, Out <: std.Boolean](tf : Boolean[T])(implicit id : OpAuxBoolean[AcceptNonLiteral[Id[T]], Out]) : Out = macro Builder.Macro.toNumValue2[Boolean[_], Out]
     implicit def unsafeTF2Num(tf : Boolean[_]) : std.Boolean = macro Builder.Macro.toNumValue[Boolean[_], std.Boolean]

--- a/src/test/scala_2.13+/singleton/twoface/CheckedIntSpec.scala
+++ b/src/test/scala_2.13+/singleton/twoface/CheckedIntSpec.scala
@@ -46,6 +46,7 @@ class CheckedIntSpec extends Properties("Checked.Int") {
   }
 
   property("Run-time checks") = wellTyped {
+    smallerThan50Seq(1,2,3)
     smallerThan50Seq(us(1),2,3)
     smallerThan50(us(40))
     smallerThan50(TwoFace.Int(us(40)))
@@ -65,5 +66,7 @@ class CheckedIntSpec extends Properties("Checked.Int") {
     }
     val a = new Foo
     val b : Fooish[W.`2`.T] = a.foo(2)
+    val two = 2
+    val c : Fooish[Int] = a.foo(two)
   }
 }

--- a/src/test/scala_2.13+/singleton/twoface/CheckedStringSpec.scala
+++ b/src/test/scala_2.13+/singleton/twoface/CheckedStringSpec.scala
@@ -96,6 +96,7 @@ class CheckedStringSpec extends Properties("Checked.String") {
     }
     val a = new Foo
     val b : Fooish[W.`"World"`.T] = a.foo("World")
+    val world = "World"
+    val c : Fooish[String] = a.foo(world)
   }
-
 }

--- a/src/test/scala_2.13+/singleton/twoface/TwoFaceIntSpec.scala
+++ b/src/test/scala_2.13+/singleton/twoface/TwoFaceIntSpec.scala
@@ -424,6 +424,8 @@ class TwoFaceIntSpec extends Properties("TwoFace.Int") {
     }
     val a = new Foo
     val b : Fooish[W.`2`.T] = a.foo(2)
+    val two = 2
+    val c : Fooish[Int] = a.foo(two)
   }
 
 }


### PR DESCRIPTION
Removed most dedicated macro usages for 2.13.x while relying on the `Singleton` semantics.
Removed global implicit conversion of `Op` containers and introduced `OpContainter` for help to create dedicated implicit conversions.
