### PR TITLE
GetArg lazy return value to support by-name arguments 

### DIFF
--- a/src/main/scala/singleton/ops/impl/GeneralMacros.scala
+++ b/src/main/scala/singleton/ops/impl/GeneralMacros.scala
@@ -726,9 +726,9 @@ trait GeneralMacros {
           new $opTpe {
             type OutWide = $outTpe
             type Out = $outTpe
-            final val value: $outTpe = $valueTree
+            final lazy val value: $outTpe = $valueTree
             final val isLiteral = false
-            final val valueWide: $outTpe = $valueTree
+            final lazy val valueWide: $outTpe = $valueTree
           }
         """
       case None =>

--- a/src/test/scala/singleton/ops/GetArgSpec.scala
+++ b/src/test/scala/singleton/ops/GetArgSpec.scala
@@ -33,6 +33,15 @@ class GetArgSpec extends Properties("GetArgSpec") {
     1.extendable
   }
 
+  object ByName
+  def byName(arg : => Any)(implicit getArg : GetArg0) = getArg
+  property("By name argument not evaluated until value is read") = {
+    var byNameNotRead = true
+    val b = byName({byNameNotRead = false; ByName})
+    val preRead = byNameNotRead
+    val forceRead = b.value //now lazily invoked
+    preRead && !byNameNotRead
+  }
 
   val one = 1
   val two = 2


### PR DESCRIPTION
GetArg now supports by-name arguments by returning their value lazily.