### PR TITLE
Add OpIntercept to allow custom types and operations

### DIFF
--- a/src/main/scala/singleton/ops/OpIntercept.scala
+++ b/src/main/scala/singleton/ops/OpIntercept.scala
@@ -1,0 +1,22 @@
+package singleton.ops
+import scala.reflect.macros.whitebox
+import impl._
+
+import scala.annotation.implicitNotFound
+
+trait OpIntercept[Op <: HasOut] extends HasOut
+object OpIntercept {
+  type Aux[Op <: HasOut, Out0] = OpIntercept[Op]{type Out = Out0}
+  @implicitNotFound("Failed to cache op ${Op} with result ${Out}")
+  trait CacheResult[Op <: HasOut, Out]
+  object CacheResult {
+    implicit def call[Op <: HasOut, Out] : CacheResult[Op, Out] = macro Macro.materializeCacheResult[Op, Out]
+    final class Macro(val c: whitebox.Context) extends GeneralMacros {
+      def materializeCacheResult[
+        Op : c.WeakTypeTag,
+        Out: c.WeakTypeTag,
+      ]: c.Tree = cacheOpInterceptResult[Op, Out]
+    }
+
+  }
+}

--- a/src/main/scala/singleton/ops/impl/Op.scala
+++ b/src/main/scala/singleton/ops/impl/Op.scala
@@ -6,7 +6,11 @@ trait HasOut extends Any with Serializable {
   type Out
 }
 
-trait Op extends HasOut {
+trait HasOutValue extends HasOut {
+  val value : Out
+}
+
+trait Op extends HasOutValue {
   type OutWide
   type Out
   type OutNat <: Nat
@@ -29,7 +33,7 @@ protected[singleton] object OpGen {
   implicit def getValue[O <: Op, Out](o : Aux[O, Out]) : Out = o.value
 }
 
-trait OpCast[T, O <: Op] extends HasOut {type Out <: T; val value : Out}
+trait OpCast[T, O <: Op] extends HasOutValue {type Out <: T}
 
 
 @scala.annotation.implicitNotFound(msg = "Unable to prove type argument is a Nat.")

--- a/src/test/scala/singleton/ops/OpInterceptSpec.scala
+++ b/src/test/scala/singleton/ops/OpInterceptSpec.scala
@@ -1,0 +1,55 @@
+package singleton.ops
+
+import org.scalacheck.Properties
+import singleton.TestUtils._
+
+class OpInterceptSpec extends Properties("OpInterceptSpec") {
+
+  trait Vec[A0, A1]
+
+  implicit def `Vec+`[VL0, VL1, VR0, VR1, VO0, VO1](
+    implicit
+    opL : OpAuxGen[VL0 + VR0, VO0],
+    opR : OpAuxGen[VL1 + VR1, VO1],
+    result : OpIntercept.CacheResult[Vec[VL0, VL1] + Vec[VR0, VR1], Vec[VO0, VO1]]
+  ) : OpIntercept[Vec[VL0, VL1] + Vec[VR0, VR1]] = ???
+
+  implicit def `Vec==`[VL0, VL1, VR0, VR1, EqOut](
+    implicit
+    op : OpAuxGen[(VL0 == VR0) && (VL1 == VR1), EqOut],
+    result : OpIntercept.CacheResult[Vec[VL0, VL1] == Vec[VR0, VR1], EqOut]
+  ) : OpIntercept[Vec[VL0, VL1] == Vec[VR0, VR1]] = ???
+
+
+  property("Custom Vec Equality OK") = wellTyped {
+    val eq1 = shapeless.the[Vec[1, 2] == Vec[1, 2]]
+    val eq2 = shapeless.the[Vec[1, 2] == Vec[1, 1]]
+    implicitly[eq1.Out =:= true]
+    implicitly[eq2.Out =:= false]
+  }
+
+  property("Custom Vec Addition OK") = wellTyped {
+    val add2 = shapeless.the[Vec[1, 2] + Vec[3, 8]]
+    val add3 = shapeless.the[Vec[1, 2] + Vec[3, 8] + Vec[20, 20]]
+    implicitly[add2.Out =:= Vec[4, 10]]
+    implicitly[add3.Out =:= Vec[24, 30]]
+    val add23 = shapeless.the[add2.Out + add3.Out]
+    implicitly[add23.Out =:= Vec[28, 40]]
+  }
+
+  trait FibId
+  type Fib[P] = impl.OpMacro[FibId, P, 0, 0]
+  implicit def doFib[P, Out](
+    implicit
+    op : OpAuxGen[ITE[P == 0, 0, ITE[P == 1, 1, Fib[P - 1] + Fib[P - 2]]], Out],
+    result : OpIntercept.CacheResult[Fib[P], Out]
+  ) : OpIntercept[Fib[P]] = ???
+
+
+  property("Custom Fibonacci Op OK") = wellTyped {
+    val fib4 = shapeless.the[Fib[4]]
+    implicitly[fib4.Out =:= 3]
+    val fib10 = shapeless.the[Fib[10]]
+    implicitly[fib10.Out =:= 55]
+  }
+}


### PR DESCRIPTION
See discussion on #140 
For any operation/types that are not supported internally, the user can create an implicit for `OpIntercept[Op]` that caches the real result operation via `OpIntercept.CacheResult[Op, Out]`.

See https://github.com/fthomas/singleton-ops/compare/master...soronpo:op_intercept?expand=1#diff-b17d5bc3066a42d6ad991f1b86cbc212 for examples.

cc @erikerlandson 