### PR TITLE
RequireMsgSym[_,_,Info] and more

### DIFF
--- a/src/main/scala/singleton/ops/impl/OpId.scala
+++ b/src/main/scala/singleton/ops/impl/OpId.scala
@@ -1,6 +1,7 @@
 package singleton.ops.impl
 
 sealed trait Warn
+sealed trait Info
 sealed trait NoSym
 sealed trait OpId
 object OpId {

--- a/src/main/scala/singleton/ops/package.scala
+++ b/src/main/scala/singleton/ops/package.scala
@@ -93,6 +93,7 @@ package object ops {
   type RequireMsg[Cond,Msg] = OpMacro[OpId.Require, Cond, Msg, NoSym]
   type RequireMsgSym[Cond,Msg,Sym] = OpMacro[OpId.Require, Cond, Msg, GetType[Sym]]
   type Warn                 = impl.Warn
+  type Info                 = impl.Info
   type ToNat[P1]            = OpMacro[OpId.ToNat, P1, NP, NP]
   type ToChar[P1]           = OpMacro[OpId.ToChar, P1, NP, NP]
   type ToInt[P1]            = OpMacro[OpId.ToInt, P1, NP, NP]


### PR DESCRIPTION
This patch has the following 2 changes:

1. add Info as a validation option for RequireMsgSym

2. Warn and Info validation options for RequireMsgSym now also invoke scala compiler FontEnds logging.

The purpose of 2 is to allow warning and info logs to be identified by any build & code inspection systems, e.g. bloop language server in the following screenshot:

![Screenshot from 2021-03-30 20-13-38](https://user-images.githubusercontent.com/3441413/115310486-e3af7000-a13b-11eb-9bdd-406ca18501d9.png)

Unfortunately at this moment only INFO seems to be working. WARNING will be omitted by both scalac & bloop. It is probably caused by https://github.com/scala/bug/issues/6910.

If you know the reason for this behaviour please let me know, I'll correct it